### PR TITLE
Slot-surgery primitives for capacity birth / column probes (#811/#820)

### DIFF
--- a/param_decomp/core/ci_fn.py
+++ b/param_decomp/core/ci_fn.py
@@ -104,6 +104,25 @@ class CI:
         )
 
 
+def protect_ci(ci: CI, protected: dict[str, Array] | None) -> CI:
+    """Override protected slots to CI exactly 1 in BOTH squashings (the capacity-birth
+    lifecycle's protected-open gate): the mask pins to 1 (S1), neither adversary can touch
+    the slot, and the `where` zeroes the imp-min gradient into the underlying logit — the
+    slot is released to the minimality objective only when its protection mask drops.
+    `protected` maps a subset of sites to bool `[C]` masks; None is the no-op fast path."""
+    if protected is None:
+        return ci
+    assert set(protected) <= set(ci.lower), (sorted(protected), sorted(ci.lower))
+
+    def shielded(values: SiteDict) -> SiteDict:
+        return {
+            site: jnp.where(protected[site], 1.0, v) if site in protected else v
+            for site, v in values.items()
+        }
+
+    return CI(logits=ci.logits, lower=shielded(ci.lower), upper=shielded(ci.upper))
+
+
 @runtime_checkable
 class CIFn(Protocol):
     """`dict[InputTap, Array] -> CI`. `output_names` partition the model sites (asserted at

--- a/param_decomp/core/ci_fn.py
+++ b/param_decomp/core/ci_fn.py
@@ -890,6 +890,53 @@ def init_global_mlp_ci_fn(
 # ----------------------------- construction (placement-agnostic) -----------------------------
 
 
+def pin_ci_head_null_tail(ci_fn: CIFn, sites: tuple[SiteSpec, ...]) -> CIFn:
+    """`svd_null_tail`'s CI half: zero the final head weights and set its bias to 1 for
+    the first min(d_in, d_out) slots of each site and 0 for the null tail, so CI starts
+    exactly 1 on the SVD slots and exactly 0 elsewhere regardless of C. Gradient reaches
+    the zeroed head weights through the hidden activations, so the head trains normally.
+    New leaves are placed onto the leaf they replace (`device_put` on its sharding)."""
+
+    def head_bias(spec: SiteSpec) -> Array:
+        r = min(spec.d_in, spec.d_out)
+        return jnp.where(jnp.arange(spec.C) < r, 1.0, 0.0)
+
+    def like(new: Array, old: Array) -> Array:
+        assert new.shape == old.shape, (new.shape, old.shape)
+        return jax.device_put(new.astype(old.dtype), old.sharding)
+
+    site_by_name = {spec.name: spec for spec in sites}
+    match ci_fn:
+        case LayerwiseMLPCIFn():
+            replaced = {
+                name: eqx.tree_at(
+                    lambda m: (m.weights[-1], m.biases[-1]),
+                    mlp,
+                    (
+                        like(jnp.zeros(mlp.weights[-1].shape), mlp.weights[-1]),
+                        like(head_bias(site_by_name[name]), mlp.biases[-1]),
+                    ),
+                )
+                for name, mlp in ci_fn.site_mlps.items()
+            }
+            return eqx.tree_at(lambda f: f.site_mlps, ci_fn, replaced)
+        case GlobalMLPCIFn():
+            bias = jnp.concatenate([head_bias(site_by_name[n]) for n in ci_fn.output_names])
+            return eqx.tree_at(
+                lambda f: (f.mlp.weights[-1], f.mlp.biases[-1]),
+                ci_fn,
+                (
+                    like(jnp.zeros(ci_fn.mlp.weights[-1].shape), ci_fn.mlp.weights[-1]),
+                    like(bias, ci_fn.mlp.biases[-1]),
+                ),
+            )
+        case _:
+            raise NotImplementedError(
+                f"svd_null_tail CI-head init is built for the MLP CI fns only, not "
+                f"{type(ci_fn).__name__} (the chunkwise per-site heads need their own surgery)"
+            )
+
+
 CIFnArch = ChunkwiseTransformerCIArch | LayerwiseMLPCIArch | GlobalMLPCIArch
 """Every CI-fn architecture. Construction goes through `build_ci_fn`; sharding/placement is
 a separate, scale-driven concern (see `init_placed`), never coupled to arch type."""

--- a/param_decomp/core/components.py
+++ b/param_decomp/core/components.py
@@ -153,7 +153,7 @@ def init_stack_arrays_svd_null_tail(
         W = site_weights[spec.name].astype(jnp.float32)
         assert W.shape == (spec.d_out, spec.d_in), (spec.name, W.shape)
         r = min(spec.d_in, spec.d_out)
-        assert spec.C >= r, (
+        assert r <= spec.C, (
             f"svd_null_tail needs C >= min(d_in, d_out) at every site: "
             f"{spec.name} has C={spec.C} < {r}"
         )

--- a/param_decomp/core/components.py
+++ b/param_decomp/core/components.py
@@ -139,6 +139,49 @@ def init_stack_arrays(
     return stacked
 
 
+def init_stack_arrays_svd_null_tail(
+    sites: tuple[SiteSpec, ...], site_weights: dict[str, Array], key: Array
+) -> dict[VUShape, tuple[Array, Array]]:
+    """C-nested init: slots `[:r]` (r = min(d_in, d_out), static) carry the exact SVD
+    factorization of the site's frozen weight (`V@U == W.T` up to fp error; a zero singular
+    value yields a zero slot, so numerical rank needs no data-dependent slicing), slots
+    `[r:]` are exact nulls — U rows zero, V columns random and PREFIX-STABLE (column j is
+    keyed by its absolute index, so every C shares the same tail draw). `site_weights` is
+    keyed by site name in `weight_deltas` orientation, `[d_out, d_in]`."""
+    per_site: dict[str, tuple[Array, Array]] = {}
+    for site_idx, spec in enumerate(sites):
+        W = site_weights[spec.name].astype(jnp.float32)
+        assert W.shape == (spec.d_out, spec.d_in), (spec.name, W.shape)
+        r = min(spec.d_in, spec.d_out)
+        assert spec.C >= r, (
+            f"svd_null_tail needs C >= min(d_in, d_out) at every site: "
+            f"{spec.name} has C={spec.C} < {r}"
+        )
+        A, s, Bt = jnp.linalg.svd(W.T, full_matrices=False)  # W.T = A @ diag(s) @ Bt
+        sqrt_s = jnp.sqrt(s)
+        site_key = jax.random.fold_in(key, site_idx)
+        tail_cols = jax.vmap(
+            lambda j, sk=site_key, d=spec.d_in: jax.random.normal(jax.random.fold_in(sk, j), (d,))
+        )(jnp.arange(r, spec.C))
+        V = jnp.concatenate([A * sqrt_s, tail_cols.T * spec.d_in**-0.5], axis=1)
+        U = jnp.concatenate([sqrt_s[:, None] * Bt, jnp.zeros((spec.C - r, spec.d_out))], axis=0)
+        per_site[spec.name] = (V, U)
+    stacks = {
+        shape: (
+            jnp.stack([per_site[s.name][0] for s in specs]),
+            jnp.stack([per_site[s.name][1] for s in specs]),
+        )
+        for shape, specs in vu_shape_groups(sites).items()
+    }
+    return stacks
+
+
+def site_rank(spec: SiteSpec) -> int:
+    """The static SVD-slot count of `svd_null_tail` init: slots `[:site_rank]` start alive
+    (CI pinned 1), the rest start null (CI pinned 0)."""
+    return min(spec.d_in, spec.d_out)
+
+
 def component_stacks_from_sites(vu: dict[str, tuple[Array, Array]]) -> ComponentStacks:
     """Build the stacked `ComponentStacks` from a per-site `{name: (V, U)}` dict (site order =
     dict order). The explicit-arrays constructor for toys and tests; the trainer inits

--- a/param_decomp/core/configs.py
+++ b/param_decomp/core/configs.py
@@ -621,6 +621,16 @@ class PDConfig(BaseConfig):
             "and scales both updates by (d_in/C)^(3/4)."
         ),
     )
+    component_init: Literal["random", "svd_null_tail"] = Field(
+        default="random",
+        description=(
+            "V/U + CI-head initialization. `svd_null_tail` starts the first min(d_in, d_out) "
+            "slots at an exact SVD factorization of the target weight with CI pinned 1, and "
+            "every extra slot as an exact null (U row zero, prefix-stable random V column, CI "
+            "pinned 0) — so every C >= rank(W) starts from the same represented matrix, "
+            "reconstruction, and L0 (the C-nesting property the random init lacks)."
+        ),
+    )
     steps: PositiveInt = Field(..., description="Total number of optimisation steps")
     batch_size: PositiveInt = Field(
         ...,

--- a/param_decomp/core/configs.py
+++ b/param_decomp/core/configs.py
@@ -608,6 +608,14 @@ class PDConfig(BaseConfig):
     ci_fn_optimizer: AnyOptimizerConfig = Field(
         ..., description="Optimizer config for the CI function parameters"
     )
+    component_update_scaling: Literal["none", "c_covariant"] = Field(
+        default="none",
+        description=(
+            "Post-optimizer scaling for the bilinear V/U factors. `c_covariant` multiplies "
+            "V updates by sqrt(d_in/C) and U updates by d_in/C, so the first Adam step of "
+            "the represented matrix is approximately invariant to overcomplete C."
+        ),
+    )
     steps: PositiveInt = Field(..., description="Total number of optimisation steps")
     batch_size: PositiveInt = Field(
         ...,

--- a/param_decomp/core/configs.py
+++ b/param_decomp/core/configs.py
@@ -577,6 +577,9 @@ class PlacementTableConfig(BaseConfig):
     activations: RuleConfig
 
 
+ComponentUpdateScaling = Literal["none", "c_covariant", "c_covariant_balanced"]
+
+
 class PDConfig(BaseConfig):
     """Algorithm specification: seed, losses, optimizers, faithfulness warmup.
 
@@ -608,12 +611,14 @@ class PDConfig(BaseConfig):
     ci_fn_optimizer: AnyOptimizerConfig = Field(
         ..., description="Optimizer config for the CI function parameters"
     )
-    component_update_scaling: Literal["none", "c_covariant"] = Field(
+    component_update_scaling: ComponentUpdateScaling = Field(
         default="none",
         description=(
             "Post-optimizer scaling for the bilinear V/U factors. `c_covariant` multiplies "
             "V updates by sqrt(d_in/C) and U updates by d_in/C, so the first Adam step of "
-            "the represented matrix is approximately invariant to overcomplete C."
+            "the represented matrix is approximately invariant to overcomplete C. "
+            "`c_covariant_balanced` fixes the exact V/U scale gauge at equal factor norms "
+            "and scales both updates by (d_in/C)^(3/4)."
         ),
     )
     steps: PositiveInt = Field(..., description="Total number of optimisation steps")

--- a/param_decomp/core/controller.py
+++ b/param_decomp/core/controller.py
@@ -8,10 +8,13 @@ lore 2026-08-02--design--reconstruction-budget-control-and-demand-triggered-capa
 
 Coordinates: the controller moves `log c` where `c` multiplies the COMBINED imp+freq
 complexity force (the reciprocal of the reconstruction dual — violation drives `c`
-DOWN). Gain-free by construction: multiplicative bracketing halves the step on every
-violation/slack sign flip, and `c = 0` is an explicit OFF state rather than a tuned
-positive floor — feasibility birth requires violation with complexity fully off.
-"""
+DOWN, i.e. the feasibility boundary sits BELOW a violating `log_c` and ABOVE a slack
+one). The search is a true bracket, so one-sided sign sequences terminate: slack at
+`x` raises the feasible endpoint `lo`; violation at `x` lowers the infeasible endpoint
+`hi`; with both, bisect; with only `hi`, probe OFF (c = 0) — OFF-slack re-enters with
+a downward expansion toward `hi`, OFF-violation is the feasibility-birth condition;
+with only `lo`, expand upward under a hard guard. `c = 0` is an explicit phase, not a
+tuned positive floor. Gain-free: no controller learning rate exists to sweep."""
 
 import math
 from dataclasses import dataclass, replace
@@ -24,21 +27,28 @@ class ControllerConfig:
     """Dimensionless recon-damage tolerance: violation is `r_adv > tau`, with
     `r_adv = (R - R_unmasked) / (R_zero - R_unmasked)` computed by the caller."""
     noise_margin: float
-    """|EMA(g)| below this reads as on-target: neither violation nor slack."""
-    initial_log_step: float = math.log(2.0)
-    min_log_step: float = math.log(1.05)
-    """Bracketing resolution: at a smaller step, persistent violation transitions to OFF
-    and persistent slack holds (further complexity increase is noise-chasing)."""
+    """|r_adv - tau| below this reads as on-target: neither violation nor slack."""
+    max_log_c: float
+    """Hard guard on upward expansion (a sanity rail against unbounded growth under
+    permanent slack, not an operating point)."""
+    expand_log_step: float = math.log(4.0)
+    resolution: float = math.log(1.05)
+    """Bracket widths below this terminate the search: hold at `lo` (the largest
+    known-feasible complexity scale)."""
     dwell_windows: int = 3
     """Consecutive qualifying windows required for any lifecycle event."""
     plateau_rtol: float = 0.02
     """Relative settled-complexity change below which complexity counts as plateaued
     (the column-generation trigger, with recon on-budget)."""
+    probe_cooldown_windows: int = 6
+    """Windows to suppress plateau-triggered probes after a rejected COLUMN_PROBE."""
+    max_rejected_probes: int = 3
+    """Rejected probes before the plateau is declared terminal (NO_IMPROVING_COLUMN)."""
 
 
 class Phase(Enum):
     CONTROL = "control"
-    OFF = "off"  # complexity force fully off (c = 0); the only state feasibility birth can fire from
+    OFF = "off"  # complexity force fully off (c = 0); the only phase feasibility birth fires from
     BIRTH_PROTECTED = "birth_protected"  # a newborn slot is gate-protected; controller frozen
 
 
@@ -49,12 +59,14 @@ class Event(Enum):
     represent the target — open capacity (GradMax slot)."""
     COLUMN_PROBE = "column_probe"
     """Recon on-budget and settled complexity plateaued for `dwell_windows`: trial a
-    protected slot, to be ACCEPTED only if settled complexity falls at matched recon,
-    else rolled back (this event alone makes physical C a true upper bound; without it
-    the controller can oscillate dense-SVD <-> pruned-SVD and never use the tail)."""
+    protected slot, ACCEPTED by the caller only if settled complexity falls at matched
+    recon, else rolled back + reported via `probe_rejected` (this event alone makes
+    physical C a true upper bound)."""
     CAPACITY_EXHAUSTED = "capacity_exhausted"
-    """A birth was demanded but no inactive slot exists — a reportable terminal state,
-    never a silent clip."""
+    """A birth was demanded but no inactive slot exists — reportable, never a silent clip."""
+    NO_IMPROVING_COLUMN = "no_improving_column"
+    """`max_rejected_probes` consecutive probe rejections at the same plateau: stop
+    probing; the operating point stands."""
 
 
 @dataclass(frozen=True)
@@ -70,22 +82,26 @@ class WindowSummary:
 class ControllerState:
     phase: Phase
     log_c: float  # meaningful only outside OFF
-    log_step: float
-    last_sign: int  # sign of the previous window's g (0 before the first move)
-    dwell: int  # consecutive qualifying windows toward the phase's pending event
+    lo: float | None  # highest log_c OBSERVED slack/on-target (feasible endpoint)
+    hi: float | None  # lowest log_c OBSERVED violating (infeasible endpoint)
+    dwell: int
     prev_complexity: float | None
     protect_windows_left: int
+    probe_cooldown: int
+    rejected_probes: int
 
     @staticmethod
-    def initial(log_c: float, cfg: ControllerConfig) -> "ControllerState":
+    def initial(log_c: float) -> "ControllerState":
         return ControllerState(
             phase=Phase.CONTROL,
             log_c=log_c,
-            log_step=cfg.initial_log_step,
-            last_sign=0,
+            lo=None,
+            hi=None,
             dwell=0,
             prev_complexity=None,
             protect_windows_left=0,
+            probe_cooldown=0,
+            rejected_probes=0,
         )
 
     @property
@@ -99,12 +115,54 @@ class Action:
     event: Event
 
 
+def probe_rejected(state: ControllerState, cfg: ControllerConfig) -> ControllerState:
+    """Caller reports a rolled-back COLUMN_PROBE: start the cooldown and count it.
+    The trial slot is back to exact null, so control resumes where it left off."""
+    return replace(
+        state,
+        phase=Phase.CONTROL,
+        protect_windows_left=0,
+        probe_cooldown=cfg.probe_cooldown_windows,
+        rejected_probes=state.rejected_probes + 1,
+    )
+
+
+def probe_accepted(state: ControllerState) -> ControllerState:
+    """Caller reports an accepted COLUMN_PROBE: the landscape changed — fresh bracket,
+    rejection count cleared (a new plateau earns new probes)."""
+    return replace(
+        state,
+        phase=Phase.CONTROL,
+        lo=None,
+        hi=None,
+        dwell=0,
+        protect_windows_left=0,
+        probe_cooldown=0,
+        rejected_probes=0,
+    )
+
+
+def _next_log_c(state: ControllerState, cfg: ControllerConfig) -> float | None:
+    """The bracket search's next coefficient, or None to transition OFF. Requires the
+    endpoints already updated for the current window."""
+    match state.lo, state.hi:
+        case lo, hi if lo is not None and hi is not None:
+            if hi - lo < cfg.resolution:
+                return lo  # converged: hold at the largest known-feasible scale
+            return (lo + hi) / 2.0
+        case None, hi if hi is not None:
+            return None  # never seen feasible at c > 0: probe OFF
+        case lo, None if lo is not None:
+            return min(lo + cfg.expand_log_step, cfg.max_log_c)  # expand under the guard
+    raise AssertionError("unreachable: a window always sets one endpoint")
+
+
 def controller_update(
     state: ControllerState, window: WindowSummary, cfg: ControllerConfig, protect_windows: int
 ) -> Action:
     """One controller decision from one settled window. The caller applies `state.c` as
-    the next windows' complexity_scale, executes the event (birth surgery / probe /
-    report), and on birth re-enters via the returned BIRTH_PROTECTED state."""
+    the next windows' complexity_scale and executes the event (birth surgery / probe /
+    report); probe verdicts come back via `probe_accepted` / `probe_rejected`."""
     g = window.r_adv - cfg.tau
     sign = 0 if abs(g) <= cfg.noise_margin else (1 if g > 0 else -1)
 
@@ -113,22 +171,19 @@ def controller_update(
             left = state.protect_windows_left - 1
             if left > 0:
                 return Action(replace(state, protect_windows_left=left), Event.NONE)
-            # protection expires -> resume control; bracketing restarts (the newborn
-            # changed the landscape, the old bracket is stale)
+            # feasibility-birth protection expiry; probe verdicts arrive via
+            # probe_accepted/probe_rejected instead. Fresh bracket: the newborn moved
+            # the landscape.
             return Action(
                 replace(
-                    state,
-                    phase=Phase.CONTROL,
-                    log_step=cfg.initial_log_step,
-                    last_sign=0,
-                    dwell=0,
+                    state, phase=Phase.CONTROL, lo=None, hi=None, dwell=0,
                     protect_windows_left=0,
-                ),
+                ),  # fmt: skip
                 Event.NONE,
             )
 
         case Phase.OFF:
-            if sign > 0:  # still violating with complexity fully off -> demand capacity
+            if sign > 0:  # violating with complexity fully off -> demand capacity
                 dwell = state.dwell + 1
                 if dwell < cfg.dwell_windows:
                     return Action(replace(state, dwell=dwell), Event.NONE)
@@ -136,73 +191,67 @@ def controller_update(
                     return Action(replace(state, dwell=0), Event.CAPACITY_EXHAUSTED)
                 return Action(
                     replace(
-                        state,
-                        phase=Phase.BIRTH_PROTECTED,
-                        dwell=0,
+                        state, phase=Phase.BIRTH_PROTECTED, dwell=0,
                         protect_windows_left=protect_windows,
-                    ),
+                    ),  # fmt: skip
                     Event.FEASIBILITY_BIRTH,
                 )
-            if sign < 0:  # slack returned -> re-enter control at the last coefficient
-                return Action(
-                    replace(
-                        state,
-                        phase=Phase.CONTROL,
-                        log_step=cfg.initial_log_step,
-                        last_sign=0,
-                        dwell=0,
-                    ),
-                    Event.NONE,
-                )
-            return Action(replace(state, dwell=0), Event.NONE)
+            # OFF is feasible: re-enter control expanding DOWNWARD toward hi (feasibility
+            # exists somewhere below it; OFF itself is not a finite bracket endpoint)
+            assert state.hi is not None, "OFF is only reachable after a violation set hi"
+            return Action(
+                replace(
+                    state,
+                    phase=Phase.CONTROL,
+                    log_c=state.hi - cfg.expand_log_step,
+                    dwell=0,
+                ),
+                Event.NONE,
+            )
 
         case Phase.CONTROL:
+            cooled = replace(state, probe_cooldown=max(0, state.probe_cooldown - 1))
             if sign == 0:
-                # on-target: complexity-plateau check drives column generation
                 plateaued = (
-                    state.prev_complexity is not None
-                    and abs(window.complexity - state.prev_complexity)
-                    <= cfg.plateau_rtol * abs(state.prev_complexity)
+                    cooled.prev_complexity is not None
+                    and abs(window.complexity - cooled.prev_complexity)
+                    <= cfg.plateau_rtol * abs(cooled.prev_complexity)
                 )
-                dwell = state.dwell + 1 if plateaued else 0
-                next_state = replace(state, dwell=dwell, prev_complexity=window.complexity)
-                if dwell < cfg.dwell_windows:
+                dwell = cooled.dwell + 1 if plateaued else 0
+                next_state = replace(
+                    cooled,
+                    lo=max(cooled.lo, cooled.log_c) if cooled.lo is not None else cooled.log_c,
+                    dwell=dwell,
+                    prev_complexity=window.complexity,
+                )
+                if dwell < cfg.dwell_windows or state.probe_cooldown > 0:
                     return Action(next_state, Event.NONE)
+                if next_state.rejected_probes >= cfg.max_rejected_probes:
+                    return Action(replace(next_state, dwell=0), Event.NO_IMPROVING_COLUMN)
                 if not window.spare_slot_exists:
                     return Action(replace(next_state, dwell=0), Event.CAPACITY_EXHAUSTED)
                 return Action(
                     replace(
-                        next_state,
-                        phase=Phase.BIRTH_PROTECTED,
-                        dwell=0,
+                        next_state, phase=Phase.BIRTH_PROTECTED, dwell=0,
                         protect_windows_left=protect_windows,
-                    ),
+                    ),  # fmt: skip
                     Event.COLUMN_PROBE,
                 )
-            # bracketing move: violation -> c down, slack -> c up; halve on sign flip
-            log_step = (
-                state.log_step / 2.0
-                if state.last_sign != 0 and sign != state.last_sign
-                else state.log_step
-            )
-            if log_step < cfg.min_log_step and sign > 0:
-                # bracket exhausted while still violating: complexity force OFF
-                return Action(
-                    replace(state, phase=Phase.OFF, dwell=0, last_sign=0), Event.NONE
-                )
-            if log_step < cfg.min_log_step:
-                return Action(  # exhausted with slack: hold (chasing noise upward)
-                    replace(state, last_sign=sign, dwell=0, prev_complexity=window.complexity),
-                    Event.NONE,
-                )
-            return Action(
-                replace(
-                    state,
-                    log_c=state.log_c - sign * log_step,
-                    log_step=log_step,
-                    last_sign=sign,
+            if sign > 0:
+                updated = replace(
+                    cooled,
+                    hi=min(cooled.hi, cooled.log_c) if cooled.hi is not None else cooled.log_c,
                     dwell=0,
                     prev_complexity=window.complexity,
-                ),
-                Event.NONE,
-            )
+                )
+            else:
+                updated = replace(
+                    cooled,
+                    lo=max(cooled.lo, cooled.log_c) if cooled.lo is not None else cooled.log_c,
+                    dwell=0,
+                    prev_complexity=window.complexity,
+                )
+            target = _next_log_c(updated, cfg)
+            if target is None:
+                return Action(replace(updated, phase=Phase.OFF), Event.NONE)
+            return Action(replace(updated, log_c=target), Event.NONE)

--- a/param_decomp/core/controller.py
+++ b/param_decomp/core/controller.py
@@ -107,7 +107,13 @@ class ControllerState:
 
     @property
     def c(self) -> float:
-        return 0.0 if self.phase is Phase.OFF else math.exp(self.log_c)
+        """BIRTH_PROTECTED is reachable only via FEASIBILITY_BIRTH (probes have their own
+        phase), and that birth fired because complexity-OFF was still infeasible —
+        reapplying pressure mid-growth would kill the newborn, so complexity stays OFF
+        through protected settling."""
+        if self.phase in (Phase.OFF, Phase.BIRTH_PROTECTED):
+            return 0.0
+        return math.exp(self.log_c)
 
 
 @dataclass(frozen=True)
@@ -182,12 +188,15 @@ def controller_update(
             if left > 0:
                 return Action(replace(state, protect_windows_left=left), Event.NONE)
             # feasibility protection expiry: the newborn moved the landscape -> fresh
-            # bracket, stale plateau and rejection lineage cleared.
+            # bracket, stale plateau and rejection lineage cleared, and control re-enters
+            # from a deliberately GENTLER probe than the last known-violating coefficient
+            # (complexity was OFF throughout protection; snapping back to exp(log_c)
+            # would re-test the value that already failed).
             return Action(
                 replace(
-                    state, phase=Phase.CONTROL, lo=None, hi=None, dwell=0,
-                    prev_complexity=None, protect_windows_left=0, probe_cooldown=0,
-                    rejected_probes=0,
+                    state, phase=Phase.CONTROL, log_c=state.log_c - cfg.expand_log_step,
+                    lo=None, hi=None, dwell=0, prev_complexity=None,
+                    protect_windows_left=0, probe_cooldown=0, rejected_probes=0,
                 ),  # fmt: skip
                 Event.NONE,
             )
@@ -221,7 +230,17 @@ def controller_update(
 
         case Phase.CONTROL:
             cooled = replace(state, probe_cooldown=max(0, state.probe_cooldown - 1))
-            if sign == 0:
+            converged_at_lo = (
+                state.lo is not None
+                and state.hi is not None
+                and state.hi - state.lo < cfg.resolution
+                and state.log_c == state.lo
+            )
+            # A converged bracket holds at feasible `lo`, whose sampled point is
+            # typically slack by more than the deadband (finite resolution) — the
+            # plateau/column-probe logic must engage there too, or case-B probes
+            # starve forever behind a permanent sign<0.
+            if sign == 0 or (sign < 0 and converged_at_lo):
                 plateaued = (
                     cooled.prev_complexity is not None
                     and abs(window.complexity - cooled.prev_complexity)

--- a/param_decomp/core/controller.py
+++ b/param_decomp/core/controller.py
@@ -49,7 +49,8 @@ class ControllerConfig:
 class Phase(Enum):
     CONTROL = "control"
     OFF = "off"  # complexity force fully off (c = 0); the only phase feasibility birth fires from
-    BIRTH_PROTECTED = "birth_protected"  # a newborn slot is gate-protected; controller frozen
+    BIRTH_PROTECTED = "birth_protected"  # feasibility newborn gate-protected; expires by timer
+    PROBE_PENDING = "probe_pending"  # a COLUMN_PROBE trial is out; exits ONLY via a verdict
 
 
 class Event(Enum):
@@ -117,7 +118,9 @@ class Action:
 
 def probe_rejected(state: ControllerState, cfg: ControllerConfig) -> ControllerState:
     """Caller reports a rolled-back COLUMN_PROBE: start the cooldown and count it.
-    The trial slot is back to exact null, so control resumes where it left off."""
+    The trial slot is back to exact null, so control resumes where it left off (the
+    plateau is the SAME, so prev_complexity is retained)."""
+    assert state.phase is Phase.PROBE_PENDING, state.phase
     return replace(
         state,
         phase=Phase.CONTROL,
@@ -130,12 +133,14 @@ def probe_rejected(state: ControllerState, cfg: ControllerConfig) -> ControllerS
 def probe_accepted(state: ControllerState) -> ControllerState:
     """Caller reports an accepted COLUMN_PROBE: the landscape changed — fresh bracket,
     rejection count cleared (a new plateau earns new probes)."""
+    assert state.phase is Phase.PROBE_PENDING, state.phase
     return replace(
         state,
         phase=Phase.CONTROL,
         lo=None,
         hi=None,
         dwell=0,
+        prev_complexity=None,
         protect_windows_left=0,
         probe_cooldown=0,
         rejected_probes=0,
@@ -167,17 +172,22 @@ def controller_update(
     sign = 0 if abs(g) <= cfg.noise_margin else (1 if g > 0 else -1)
 
     match state.phase:
+        case Phase.PROBE_PENDING:
+            # a trial is out: the caller drives it and reports via probe_accepted /
+            # probe_rejected — time NEVER ages a probe back into control.
+            return Action(state, Event.NONE)
+
         case Phase.BIRTH_PROTECTED:
             left = state.protect_windows_left - 1
             if left > 0:
                 return Action(replace(state, protect_windows_left=left), Event.NONE)
-            # feasibility-birth protection expiry; probe verdicts arrive via
-            # probe_accepted/probe_rejected instead. Fresh bracket: the newborn moved
-            # the landscape.
+            # feasibility protection expiry: the newborn moved the landscape -> fresh
+            # bracket, stale plateau and rejection lineage cleared.
             return Action(
                 replace(
                     state, phase=Phase.CONTROL, lo=None, hi=None, dwell=0,
-                    protect_windows_left=0,
+                    prev_complexity=None, protect_windows_left=0, probe_cooldown=0,
+                    rejected_probes=0,
                 ),  # fmt: skip
                 Event.NONE,
             )
@@ -231,10 +241,7 @@ def controller_update(
                 if not window.spare_slot_exists:
                     return Action(replace(next_state, dwell=0), Event.CAPACITY_EXHAUSTED)
                 return Action(
-                    replace(
-                        next_state, phase=Phase.BIRTH_PROTECTED, dwell=0,
-                        protect_windows_left=protect_windows,
-                    ),  # fmt: skip
+                    replace(next_state, phase=Phase.PROBE_PENDING, dwell=0),
                     Event.COLUMN_PROBE,
                 )
             if sign > 0:

--- a/param_decomp/core/controller.py
+++ b/param_decomp/core/controller.py
@@ -1,0 +1,208 @@
+"""Host-side recon-budget controller + capacity-lifecycle state machine (task #811).
+
+Pure logic over settled window metrics — no jax state, no trainer coupling: the loop
+feeds it one `WindowSummary` per controller window and applies the returned action
+(`StepControls` fields + a lifecycle event). Spec:
+lore 2026-08-02--design--reconstruction-budget-control-and-demand-triggered-capacity-birth
++ lore 2026-08-02--addendum--capacity-lifecycle-needs-column-generation-not-only-feasibility-birth.
+
+Coordinates: the controller moves `log c` where `c` multiplies the COMBINED imp+freq
+complexity force (the reciprocal of the reconstruction dual — violation drives `c`
+DOWN). Gain-free by construction: multiplicative bracketing halves the step on every
+violation/slack sign flip, and `c = 0` is an explicit OFF state rather than a tuned
+positive floor — feasibility birth requires violation with complexity fully off.
+"""
+
+import math
+from dataclasses import dataclass, replace
+from enum import Enum
+
+
+@dataclass(frozen=True)
+class ControllerConfig:
+    tau: float
+    """Dimensionless recon-damage tolerance: violation is `r_adv > tau`, with
+    `r_adv = (R - R_unmasked) / (R_zero - R_unmasked)` computed by the caller."""
+    noise_margin: float
+    """|EMA(g)| below this reads as on-target: neither violation nor slack."""
+    initial_log_step: float = math.log(2.0)
+    min_log_step: float = math.log(1.05)
+    """Bracketing resolution: at a smaller step, persistent violation transitions to OFF
+    and persistent slack holds (further complexity increase is noise-chasing)."""
+    dwell_windows: int = 3
+    """Consecutive qualifying windows required for any lifecycle event."""
+    plateau_rtol: float = 0.02
+    """Relative settled-complexity change below which complexity counts as plateaued
+    (the column-generation trigger, with recon on-budget)."""
+
+
+class Phase(Enum):
+    CONTROL = "control"
+    OFF = "off"  # complexity force fully off (c = 0); the only state feasibility birth can fire from
+    BIRTH_PROTECTED = "birth_protected"  # a newborn slot is gate-protected; controller frozen
+
+
+class Event(Enum):
+    NONE = "none"
+    FEASIBILITY_BIRTH = "feasibility_birth"
+    """Recon violated for `dwell_windows` with complexity OFF: the active set cannot
+    represent the target — open capacity (GradMax slot)."""
+    COLUMN_PROBE = "column_probe"
+    """Recon on-budget and settled complexity plateaued for `dwell_windows`: trial a
+    protected slot, to be ACCEPTED only if settled complexity falls at matched recon,
+    else rolled back (this event alone makes physical C a true upper bound; without it
+    the controller can oscillate dense-SVD <-> pruned-SVD and never use the tail)."""
+    CAPACITY_EXHAUSTED = "capacity_exhausted"
+    """A birth was demanded but no inactive slot exists — a reportable terminal state,
+    never a silent clip."""
+
+
+@dataclass(frozen=True)
+class WindowSummary:
+    """Settled means over one controller window, computed by the caller."""
+
+    r_adv: float  # normalized recon damage, in tau's units
+    complexity: float  # the combined S = imp_lp + beta_freq * freq (unscaled by c)
+    spare_slot_exists: bool
+
+
+@dataclass(frozen=True)
+class ControllerState:
+    phase: Phase
+    log_c: float  # meaningful only outside OFF
+    log_step: float
+    last_sign: int  # sign of the previous window's g (0 before the first move)
+    dwell: int  # consecutive qualifying windows toward the phase's pending event
+    prev_complexity: float | None
+    protect_windows_left: int
+
+    @staticmethod
+    def initial(log_c: float, cfg: ControllerConfig) -> "ControllerState":
+        return ControllerState(
+            phase=Phase.CONTROL,
+            log_c=log_c,
+            log_step=cfg.initial_log_step,
+            last_sign=0,
+            dwell=0,
+            prev_complexity=None,
+            protect_windows_left=0,
+        )
+
+    @property
+    def c(self) -> float:
+        return 0.0 if self.phase is Phase.OFF else math.exp(self.log_c)
+
+
+@dataclass(frozen=True)
+class Action:
+    state: ControllerState
+    event: Event
+
+
+def controller_update(
+    state: ControllerState, window: WindowSummary, cfg: ControllerConfig, protect_windows: int
+) -> Action:
+    """One controller decision from one settled window. The caller applies `state.c` as
+    the next windows' complexity_scale, executes the event (birth surgery / probe /
+    report), and on birth re-enters via the returned BIRTH_PROTECTED state."""
+    g = window.r_adv - cfg.tau
+    sign = 0 if abs(g) <= cfg.noise_margin else (1 if g > 0 else -1)
+
+    match state.phase:
+        case Phase.BIRTH_PROTECTED:
+            left = state.protect_windows_left - 1
+            if left > 0:
+                return Action(replace(state, protect_windows_left=left), Event.NONE)
+            # protection expires -> resume control; bracketing restarts (the newborn
+            # changed the landscape, the old bracket is stale)
+            return Action(
+                replace(
+                    state,
+                    phase=Phase.CONTROL,
+                    log_step=cfg.initial_log_step,
+                    last_sign=0,
+                    dwell=0,
+                    protect_windows_left=0,
+                ),
+                Event.NONE,
+            )
+
+        case Phase.OFF:
+            if sign > 0:  # still violating with complexity fully off -> demand capacity
+                dwell = state.dwell + 1
+                if dwell < cfg.dwell_windows:
+                    return Action(replace(state, dwell=dwell), Event.NONE)
+                if not window.spare_slot_exists:
+                    return Action(replace(state, dwell=0), Event.CAPACITY_EXHAUSTED)
+                return Action(
+                    replace(
+                        state,
+                        phase=Phase.BIRTH_PROTECTED,
+                        dwell=0,
+                        protect_windows_left=protect_windows,
+                    ),
+                    Event.FEASIBILITY_BIRTH,
+                )
+            if sign < 0:  # slack returned -> re-enter control at the last coefficient
+                return Action(
+                    replace(
+                        state,
+                        phase=Phase.CONTROL,
+                        log_step=cfg.initial_log_step,
+                        last_sign=0,
+                        dwell=0,
+                    ),
+                    Event.NONE,
+                )
+            return Action(replace(state, dwell=0), Event.NONE)
+
+        case Phase.CONTROL:
+            if sign == 0:
+                # on-target: complexity-plateau check drives column generation
+                plateaued = (
+                    state.prev_complexity is not None
+                    and abs(window.complexity - state.prev_complexity)
+                    <= cfg.plateau_rtol * abs(state.prev_complexity)
+                )
+                dwell = state.dwell + 1 if plateaued else 0
+                next_state = replace(state, dwell=dwell, prev_complexity=window.complexity)
+                if dwell < cfg.dwell_windows:
+                    return Action(next_state, Event.NONE)
+                if not window.spare_slot_exists:
+                    return Action(replace(next_state, dwell=0), Event.CAPACITY_EXHAUSTED)
+                return Action(
+                    replace(
+                        next_state,
+                        phase=Phase.BIRTH_PROTECTED,
+                        dwell=0,
+                        protect_windows_left=protect_windows,
+                    ),
+                    Event.COLUMN_PROBE,
+                )
+            # bracketing move: violation -> c down, slack -> c up; halve on sign flip
+            log_step = (
+                state.log_step / 2.0
+                if state.last_sign != 0 and sign != state.last_sign
+                else state.log_step
+            )
+            if log_step < cfg.min_log_step and sign > 0:
+                # bracket exhausted while still violating: complexity force OFF
+                return Action(
+                    replace(state, phase=Phase.OFF, dwell=0, last_sign=0), Event.NONE
+                )
+            if log_step < cfg.min_log_step:
+                return Action(  # exhausted with slack: hold (chasing noise upward)
+                    replace(state, last_sign=sign, dwell=0, prev_complexity=window.complexity),
+                    Event.NONE,
+                )
+            return Action(
+                replace(
+                    state,
+                    log_c=state.log_c - sign * log_step,
+                    log_step=log_step,
+                    last_sign=sign,
+                    dwell=0,
+                    prev_complexity=window.complexity,
+                ),
+                Event.NONE,
+            )

--- a/param_decomp/core/controller.py
+++ b/param_decomp/core/controller.py
@@ -156,16 +156,15 @@ def probe_accepted(state: ControllerState) -> ControllerState:
 def _next_log_c(state: ControllerState, cfg: ControllerConfig) -> float | None:
     """The bracket search's next coefficient, or None to transition OFF. Requires the
     endpoints already updated for the current window."""
-    match state.lo, state.hi:
-        case lo, hi if lo is not None and hi is not None:
-            if hi - lo < cfg.resolution:
-                return lo  # converged: hold at the largest known-feasible scale
-            return (lo + hi) / 2.0
-        case None, hi if hi is not None:
-            return None  # never seen feasible at c > 0: probe OFF
-        case lo, None if lo is not None:
-            return min(lo + cfg.expand_log_step, cfg.max_log_c)  # expand under the guard
-    raise AssertionError("unreachable: a window always sets one endpoint")
+    lo, hi = state.lo, state.hi
+    if lo is not None and hi is not None:
+        if hi - lo < cfg.resolution:
+            return lo  # converged: hold at the largest known-feasible scale
+        return (lo + hi) / 2.0
+    if hi is not None:
+        return None  # never seen feasible at c > 0: probe OFF
+    assert lo is not None, "a window always sets one endpoint"
+    return min(lo + cfg.expand_log_step, cfg.max_log_c)  # expand under the guard
 
 
 def controller_update(

--- a/param_decomp/core/controller.py
+++ b/param_decomp/core/controller.py
@@ -193,9 +193,16 @@ def controller_update(
             # would re-test the value that already failed).
             return Action(
                 replace(
-                    state, phase=Phase.CONTROL, log_c=state.log_c - cfg.expand_log_step,
-                    lo=None, hi=None, dwell=0, prev_complexity=None,
-                    protect_windows_left=0, probe_cooldown=0, rejected_probes=0,
+                    state,
+                    phase=Phase.CONTROL,
+                    log_c=state.log_c - cfg.expand_log_step,
+                    lo=None,
+                    hi=None,
+                    dwell=0,
+                    prev_complexity=None,
+                    protect_windows_left=0,
+                    probe_cooldown=0,
+                    rejected_probes=0,
                 ),  # fmt: skip
                 Event.NONE,
             )
@@ -209,7 +216,9 @@ def controller_update(
                     return Action(replace(state, dwell=0), Event.CAPACITY_EXHAUSTED)
                 return Action(
                     replace(
-                        state, phase=Phase.BIRTH_PROTECTED, dwell=0,
+                        state,
+                        phase=Phase.BIRTH_PROTECTED,
+                        dwell=0,
                         protect_windows_left=protect_windows,
                     ),  # fmt: skip
                     Event.FEASIBILITY_BIRTH,
@@ -240,11 +249,9 @@ def controller_update(
             # plateau/column-probe logic must engage there too, or case-B probes
             # starve forever behind a permanent sign<0.
             if sign == 0 or (sign < 0 and converged_at_lo):
-                plateaued = (
-                    cooled.prev_complexity is not None
-                    and abs(window.complexity - cooled.prev_complexity)
-                    <= cfg.plateau_rtol * abs(cooled.prev_complexity)
-                )
+                plateaued = cooled.prev_complexity is not None and abs(
+                    window.complexity - cooled.prev_complexity
+                ) <= cfg.plateau_rtol * abs(cooled.prev_complexity)
                 dwell = cooled.dwell + 1 if plateaued else 0
                 next_state = replace(
                     cooled,

--- a/param_decomp/core/init_placed.py
+++ b/param_decomp/core/init_placed.py
@@ -33,6 +33,8 @@ from param_decomp.core.components import (
     ComponentStacks,
     SiteSpec,
     init_component_stacks,
+    init_stack_arrays_svd_null_tail,
+    site_slots_for,
 )
 from param_decomp.core.configs import SourceShape
 from param_decomp.core.model import PositionAxis, Positioned, Positionless
@@ -49,6 +51,28 @@ def init_component_stacks_placed(
     abstract = eqx.filter_eval_shape(partial(init_component_stacks, sites), key)
     placement = component_stacks_shardings(abstract, rules)
     return jax.jit(partial(init_component_stacks, sites), out_shardings=placement)(key)
+
+
+def init_component_stacks_svd_null_tail_placed(
+    sites: tuple[SiteSpec, ...],
+    site_weights: dict[str, Array],
+    key: PRNGKeyArray,
+    rules: PlacementRules,
+) -> ComponentStacks:
+    """`svd_null_tail` V/U init (see `PDConfig.component_init`), placed like
+    `init_component_stacks_placed`. `site_weights` are the frozen weights in
+    `weight_deltas` orientation (`[d_out, d_in]` per site), traced args so the SVD runs
+    device-side under the same jit+out_shardings pattern."""
+
+    def init(weights: dict[str, Array], k: PRNGKeyArray) -> ComponentStacks:
+        return ComponentStacks(
+            stacks=init_stack_arrays_svd_null_tail(sites, weights, k),
+            site_slots=site_slots_for(sites),
+        )
+
+    abstract = eqx.filter_eval_shape(init, site_weights, key)
+    placement = component_stacks_shardings(abstract, rules)
+    return jax.jit(init, out_shardings=placement)(site_weights, key)
 
 
 def init_ci_fn_placed(

--- a/param_decomp/core/run.py
+++ b/param_decomp/core/run.py
@@ -61,7 +61,7 @@ from param_decomp.core.run_state import (
     configure_component_optimizer,
     init_train_state,
 )
-from param_decomp.core.train import TrainState, make_faith_warmup_step, make_train_step
+from param_decomp.core.train import StepControls, TrainState, make_faith_warmup_step, make_train_step
 
 
 @dataclasses.dataclass(frozen=True)
@@ -669,7 +669,9 @@ def run_decomposition_training[EvalContextT](
 
     for step in range(start_step, pd.steps):
         batch = sample_batch(step)
-        state, metrics = step_fn(model, state, batch, random.fold_in(run_key, step))
+        state, metrics = step_fn(
+            model, state, batch, random.fold_in(run_key, step), StepControls.constant()
+        )
 
         grad_norm_summary_window.append(
             {k: v for k, v in metrics.items() if k.startswith("grad_norms/summary/")}

--- a/param_decomp/core/run.py
+++ b/param_decomp/core/run.py
@@ -55,7 +55,12 @@ from param_decomp.core.metrics import BarChart, LogRecord, PNGImage
 from param_decomp.core.model import DecomposedModel, PositionAxis
 from param_decomp.core.objective import build_objective
 from param_decomp.core.placement import PlacementRules, component_stacks_audit
-from param_decomp.core.run_state import build_optimizers, init_train_state
+from param_decomp.core.run_state import (
+    balance_component_stacks,
+    build_optimizers,
+    configure_component_optimizer,
+    init_train_state,
+)
 from param_decomp.core.train import TrainState, make_faith_warmup_step, make_train_step
 
 
@@ -507,6 +512,11 @@ def _init_or_restore_state(
         # composition root before this engine is entered.
         prov = run.resume_provenance
         state = init_from_parent(prov.parent_run_dir / "ckpts", prov.parent_step, state)
+        if pd.component_update_scaling == "c_covariant_balanced":
+            balanced, _ = balance_component_stacks(state.decomposition.components)
+            state = dataclasses.replace(
+                state, decomposition=dataclasses.replace(state.decomposition, components=balanced)
+            )
         save_state(checkpoint_manager, 0, state)
         if is_main:
             print(
@@ -517,8 +527,12 @@ def _init_or_restore_state(
         return state, 0
 
     if pd.faithfulness_warmup_steps > 0:
-        faith_warmup_optimizer = optax.adamw(
-            pd.faithfulness_warmup_lr, weight_decay=pd.faithfulness_warmup_weight_decay
+        faith_warmup_optimizer = configure_component_optimizer(
+            optax.adamw(
+                pd.faithfulness_warmup_lr, weight_decay=pd.faithfulness_warmup_weight_decay
+            ),
+            pd.component_update_scaling,
+            pd.components_optimizer,
         )
         faith_warmup_opt_state = faith_warmup_optimizer.init(
             eqx.filter(state.decomposition.components, eqx.is_array)

--- a/param_decomp/core/run.py
+++ b/param_decomp/core/run.py
@@ -61,7 +61,12 @@ from param_decomp.core.run_state import (
     configure_component_optimizer,
     init_train_state,
 )
-from param_decomp.core.train import StepControls, TrainState, make_faith_warmup_step, make_train_step
+from param_decomp.core.train import (
+    StepControls,
+    TrainState,
+    make_faith_warmup_step,
+    make_train_step,
+)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/param_decomp/core/run_state.py
+++ b/param_decomp/core/run_state.py
@@ -20,6 +20,7 @@ from jaxtyping import Array, PRNGKeyArray
 
 from param_decomp.core.adversary import PersistentAdversary, init_sources_adam_state
 from param_decomp.core.ci_fn import ChunkwiseTransformerCIArch, CIFnArch
+from param_decomp.core.components import ComponentStacks
 from param_decomp.core.configs import (
     AdamPGDConfig,
     AdamWOptimizerConfig,
@@ -74,6 +75,38 @@ def clip_by_global_norm_with_eps(max_norm: float, eps: float) -> optax.GradientT
         scale = jnp.minimum(max_norm / (global_norm + eps), 1.0)
         updates = jax.tree.map(lambda g: g * scale, updates)
         return updates, state
+
+    return optax.GradientTransformation(init, update)
+
+
+def scale_component_updates_c_covariant() -> optax.GradientTransformation:
+    """Scale post-Adam V/U updates so the represented-matrix step transfers across C.
+
+    With the canonical init ``V~N(0, d_in^-1)``, ``U~N(0, C^-1)``, Adam's first
+    per-parameter step has approximately fixed magnitude. In function space, ``V dU``
+    therefore grows as C and ``dV U`` as sqrt(C). Multiplying the already-preconditioned
+    updates by ``d_in/C`` and ``sqrt(d_in/C)`` respectively makes both terms C-invariant,
+    anchored to the configured LR at C=d_in. The scaling must follow Adam: applying it to
+    raw gradients would be cancelled by Adam's second-moment normalization.
+    """
+
+    def init(params: optax.Params) -> optax.EmptyState:
+        assert isinstance(params, ComponentStacks)
+        return optax.EmptyState()
+
+    def update(
+        updates: optax.Updates, state: optax.OptState, params: optax.Params | None = None
+    ) -> tuple[optax.Updates, optax.OptState]:
+        del params
+        assert isinstance(updates, ComponentStacks)
+        stacks = {
+            shape: (
+                dV * (shape[0] / shape[2]) ** 0.5,
+                dU * (shape[0] / shape[2]),
+            )
+            for shape, (dV, dU) in updates.stacks.items()
+        }
+        return ComponentStacks(stacks=stacks, site_slots=updates.site_slots), state
 
     return optax.GradientTransformation(init, update)
 
@@ -147,6 +180,14 @@ def build_optimizers(pd: PDConfig, ci_fn_arch: CIFnArch, mesh: Mesh | None):
     opt_vu = _optimizer_with_clip(
         pd.components_optimizer, sched_vu, stacked_muon_dimension_numbers, mesh=mesh
     )
+    match pd.component_update_scaling:
+        case "none":
+            pass
+        case "c_covariant":
+            assert isinstance(pd.components_optimizer, AdamWOptimizerConfig), (
+                "c_covariant component scaling is derived for AdamW updates"
+            )
+            opt_vu = optax.chain(opt_vu, scale_component_updates_c_covariant())
     ci_muon_dim_nums = (
         stacked_muon_dimension_numbers
         if isinstance(ci_fn_arch, ChunkwiseTransformerCIArch)

--- a/param_decomp/core/run_state.py
+++ b/param_decomp/core/run_state.py
@@ -8,6 +8,7 @@ optimizer-state structure.
 """
 
 from collections.abc import Callable
+from typing import NamedTuple
 
 import equinox as eqx
 import jax
@@ -24,6 +25,7 @@ from param_decomp.core.components import ComponentStacks
 from param_decomp.core.configs import (
     AdamPGDConfig,
     AdamWOptimizerConfig,
+    ComponentUpdateScaling,
     MuonOptimizerConfig,
     PDConfig,
 )
@@ -111,6 +113,120 @@ def scale_component_updates_c_covariant() -> optax.GradientTransformation:
     return optax.GradientTransformation(init, update)
 
 
+class GaugeBalancedState(NamedTuple):
+    inner_state: optax.OptState
+
+
+def balance_component_stacks(
+    components: ComponentStacks,
+) -> tuple[ComponentStacks, dict[tuple[int, int, int], Array]]:
+    """Choose the minimum-factor-norm representative of every non-null rank-one term.
+
+    ``V_c U_c`` has the exact gauge ``(a V_c)(U_c / a)``. The unique positive scale that
+    makes both factor norms equal is ``a=sqrt(||U_c||/||V_c||)``. A component with either
+    factor exactly zero is already functionally null and has no finite balanced
+    representative, so it stays untouched.
+    """
+    scales: dict[tuple[int, int, int], Array] = {}
+    stacks: dict[tuple[int, int, int], tuple[Array, Array]] = {}
+    for shape, (V, U) in components.stacks.items():
+        v_norm = jnp.linalg.norm(V, axis=1)
+        u_norm = jnp.linalg.norm(U, axis=2)
+        non_null = (v_norm != 0) & (u_norm != 0)
+        ratio = jnp.where(non_null, u_norm, 1.0) / jnp.where(non_null, v_norm, 1.0)
+        scale = jnp.sqrt(ratio)
+        scales[shape] = scale
+        stacks[shape] = (V * scale[:, None, :], U / scale[:, :, None])
+    return ComponentStacks(stacks=stacks, site_slots=components.site_slots), scales
+
+
+def _transform_adam_moments_to_balanced_gauge(
+    state: optax.OptState, scales: dict[tuple[int, int, int], Array]
+) -> optax.OptState:
+    """Transform Adam covector moments under ``V'=aV, U'=U/a``.
+
+    Gradients transform inversely to parameters, so ``m_V'=m_V/a``,
+    ``nu_V'=nu_V/a²``, ``m_U'=a m_U``, and ``nu_U'=a² nu_U``.
+    """
+
+    def transform(x: object) -> object:
+        if not isinstance(x, optax.ScaleByAdamState):
+            return x
+        assert isinstance(x.mu, ComponentStacks) and isinstance(x.nu, ComponentStacks)
+        mu_stacks = {
+            shape: (mV / scales[shape][:, None, :], mU * scales[shape][:, :, None])
+            for shape, (mV, mU) in x.mu.stacks.items()
+        }
+        nu_stacks = {
+            shape: (
+                nV / scales[shape][:, None, :] ** 2,
+                nU * scales[shape][:, :, None] ** 2,
+            )
+            for shape, (nV, nU) in x.nu.stacks.items()
+        }
+        return optax.ScaleByAdamState(
+            count=x.count,
+            mu=ComponentStacks(stacks=mu_stacks, site_slots=x.mu.site_slots),
+            nu=ComponentStacks(stacks=nu_stacks, site_slots=x.nu.site_slots),
+        )
+
+    return jax.tree.map(transform, state, is_leaf=lambda x: isinstance(x, optax.ScaleByAdamState))
+
+
+def gauge_balance_component_optimizer(
+    inner: optax.GradientTransformation,
+) -> optax.GradientTransformation:
+    """Retract each Adam step to balanced V/U gauge and carry its moments with it."""
+
+    def init(params: optax.Params) -> GaugeBalancedState:
+        assert isinstance(params, ComponentStacks)
+        return GaugeBalancedState(inner.init(params))
+
+    def update(
+        updates: optax.Updates,
+        state: GaugeBalancedState,
+        params: optax.Params | None = None,
+    ) -> tuple[optax.Updates, GaugeBalancedState]:
+        assert isinstance(updates, ComponentStacks)
+        assert isinstance(params, ComponentStacks)
+        inner_updates, inner_state = inner.update(updates, state.inner_state, params)
+        assert isinstance(inner_updates, ComponentStacks)
+        proposed = optax.apply_updates(params, inner_updates)
+        assert isinstance(proposed, ComponentStacks)
+        balanced, scales = balance_component_stacks(proposed)
+        balanced_updates = jax.tree.map(lambda new, old: new - old, balanced, params)
+        inner_state = _transform_adam_moments_to_balanced_gauge(inner_state, scales)
+        return balanced_updates, GaugeBalancedState(inner_state)
+
+    return optax.GradientTransformation(init, update)
+
+
+def scale_component_updates_c_covariant_balanced() -> optax.GradientTransformation:
+    """C-covariant Adam scaling for balanced factors.
+
+    At canonical balanced initialization both factor entries scale as C^-1/4, so either
+    first-order product update grows as C^3/4. Scaling both post-Adam factor updates by
+    ``(d_in/C)^3/4`` removes that growth, anchored to the configured LR at C=d_in.
+    """
+
+    def init(params: optax.Params) -> optax.EmptyState:
+        assert isinstance(params, ComponentStacks)
+        return optax.EmptyState()
+
+    def update(
+        updates: optax.Updates, state: optax.OptState, params: optax.Params | None = None
+    ) -> tuple[optax.Updates, optax.OptState]:
+        del params
+        assert isinstance(updates, ComponentStacks)
+        stacks = {
+            shape: (dV * (shape[0] / shape[2]) ** 0.75, dU * (shape[0] / shape[2]) ** 0.75)
+            for shape, (dV, dU) in updates.stacks.items()
+        }
+        return ComponentStacks(stacks=stacks, site_slots=updates.site_slots), state
+
+    return optax.GradientTransformation(init, update)
+
+
 def stacked_muon_dimension_numbers(params: optax.Params) -> optax.Params:
     """Muon leaf labeling for matrix-STACK trees: every 3D leaf is a `[stack, a, b]` stack
     of matrices — orthogonalize the trailing two axes, stack axis batched — and everything
@@ -168,6 +284,35 @@ def _optimizer_with_clip(
     return optax.chain(clip_by_global_norm_with_eps(opt.grad_clip_norm, eps=1e-6), inner)
 
 
+def configure_component_optimizer(
+    optimizer: optax.GradientTransformation,
+    update_scaling: ComponentUpdateScaling,
+    config: AdamWOptimizerConfig | MuonOptimizerConfig,
+) -> optax.GradientTransformation:
+    """Apply the V/U post-optimizer rule to any component optimizer phase.
+
+    Main training and faithfulness warmup use separate Adam instances; routing both through
+    this boundary prevents warmup from silently reintroducing the C/gauge dependence that
+    the configured main update removes.
+    """
+    match update_scaling:
+        case "none":
+            return optimizer
+        case "c_covariant":
+            assert isinstance(config, AdamWOptimizerConfig), (
+                "c_covariant component scaling is derived for AdamW updates"
+            )
+            return optax.chain(optimizer, scale_component_updates_c_covariant())
+        case "c_covariant_balanced":
+            assert isinstance(config, AdamWOptimizerConfig), (
+                "c_covariant_balanced component scaling is derived for AdamW updates"
+            )
+            scaled = optax.chain(optimizer, scale_component_updates_c_covariant_balanced())
+            return gauge_balance_component_optimizer(scaled)
+        case _:
+            raise AssertionError(update_scaling)
+
+
 def build_optimizers(pd: PDConfig, ci_fn_arch: CIFnArch, mesh: Mesh | None):
     """Returns (opt_vu, opt_ci, schedules): the schedule fns are returned too so the
     log path reports the exact LR the optimizer applies (single source of truth).
@@ -180,14 +325,9 @@ def build_optimizers(pd: PDConfig, ci_fn_arch: CIFnArch, mesh: Mesh | None):
     opt_vu = _optimizer_with_clip(
         pd.components_optimizer, sched_vu, stacked_muon_dimension_numbers, mesh=mesh
     )
-    match pd.component_update_scaling:
-        case "none":
-            pass
-        case "c_covariant":
-            assert isinstance(pd.components_optimizer, AdamWOptimizerConfig), (
-                "c_covariant component scaling is derived for AdamW updates"
-            )
-            opt_vu = optax.chain(opt_vu, scale_component_updates_c_covariant())
+    opt_vu = configure_component_optimizer(
+        opt_vu, pd.component_update_scaling, pd.components_optimizer
+    )
     ci_muon_dim_nums = (
         stacked_muon_dimension_numbers
         if isinstance(ci_fn_arch, ChunkwiseTransformerCIArch)
@@ -237,6 +377,9 @@ def init_train_state(
     )
     decomposition = init_decomposition(model, ci_fn_arch, init_key, mesh, rules)
     components, ci_fn = decomposition.components, decomposition.ci_fn
+    if pd.component_update_scaling == "c_covariant_balanced":
+        components, _ = balance_component_stacks(components)
+        decomposition = Decomposition(components=components, ci_fn=ci_fn)
     losses = build_objective(pd.loss_metrics, model.site_names)
     persistent = persistent_configs(losses.recon)
     term_coeff_by_state_key = {

--- a/param_decomp/core/run_state.py
+++ b/param_decomp/core/run_state.py
@@ -9,7 +9,7 @@ optimizer-state structure.
 
 from collections.abc import Callable
 from functools import partial
-from typing import Literal, NamedTuple
+from typing import Literal, NamedTuple, cast
 
 import equinox as eqx
 import jax
@@ -114,7 +114,10 @@ def scale_component_updates_c_covariant() -> optax.GradientTransformation:
             )
             for shape, (dV, dU) in updates.stacks.items()
         }
-        return ComponentStacks(stacks=stacks, site_slots=updates.site_slots), state
+        return cast(
+            optax.Updates,
+            cast(object, ComponentStacks(stacks=stacks, site_slots=updates.site_slots)),
+        ), state
 
     return optax.GradientTransformation(init, update)
 
@@ -172,8 +175,14 @@ def _transform_adam_moments_to_balanced_gauge(
         }
         return optax.ScaleByAdamState(
             count=x.count,
-            mu=ComponentStacks(stacks=mu_stacks, site_slots=x.mu.site_slots),
-            nu=ComponentStacks(stacks=nu_stacks, site_slots=x.nu.site_slots),
+            mu=cast(
+                optax.Updates,
+                cast(object, ComponentStacks(stacks=mu_stacks, site_slots=x.mu.site_slots)),
+            ),
+            nu=cast(
+                optax.Updates,
+                cast(object, ComponentStacks(stacks=nu_stacks, site_slots=x.nu.site_slots)),
+            ),
         )
 
     return jax.tree.map(transform, state, is_leaf=lambda x: isinstance(x, optax.ScaleByAdamState))
@@ -190,9 +199,10 @@ def gauge_balance_component_optimizer(
 
     def update(
         updates: optax.Updates,
-        state: GaugeBalancedState,
+        state: optax.OptState,
         params: optax.Params | None = None,
-    ) -> tuple[optax.Updates, GaugeBalancedState]:
+    ) -> tuple[optax.Updates, optax.OptState]:
+        assert isinstance(state, GaugeBalancedState)
         assert isinstance(updates, ComponentStacks)
         assert isinstance(params, ComponentStacks)
         inner_updates, inner_state = inner.update(updates, state.inner_state, params)
@@ -202,7 +212,7 @@ def gauge_balance_component_optimizer(
         balanced, scales = balance_component_stacks(proposed)
         balanced_updates = jax.tree.map(lambda new, old: new - old, balanced, params)
         inner_state = _transform_adam_moments_to_balanced_gauge(inner_state, scales)
-        return balanced_updates, GaugeBalancedState(inner_state)
+        return cast(optax.Updates, balanced_updates), GaugeBalancedState(inner_state)
 
     return optax.GradientTransformation(init, update)
 
@@ -228,7 +238,10 @@ def scale_component_updates_c_covariant_balanced() -> optax.GradientTransformati
             shape: (dV * (shape[0] / shape[2]) ** 0.75, dU * (shape[0] / shape[2]) ** 0.75)
             for shape, (dV, dU) in updates.stacks.items()
         }
-        return ComponentStacks(stacks=stacks, site_slots=updates.site_slots), state
+        return cast(
+            optax.Updates,
+            cast(object, ComponentStacks(stacks=stacks, site_slots=updates.site_slots)),
+        ), state
 
     return optax.GradientTransformation(init, update)
 
@@ -315,8 +328,8 @@ def configure_component_optimizer(
             )
             scaled = optax.chain(optimizer, scale_component_updates_c_covariant_balanced())
             return gauge_balance_component_optimizer(scaled)
-        case _:
-            raise AssertionError(update_scaling)
+        case _:  # fail-closed arm for unmigrated literals  # pyright: ignore[reportUnnecessaryComparison]
+            raise AssertionError(update_scaling)  # pyright: ignore[reportUnreachable]
 
 
 def build_optimizers(pd: PDConfig, ci_fn_arch: CIFnArch, mesh: Mesh | None):
@@ -399,9 +412,7 @@ def init_train_state(
     assert isinstance(positions, Positioned) == model.has_position_axis, (
         f"{positions} does not match the model's has_position_axis={model.has_position_axis}"
     )
-    decomposition = init_decomposition(
-        model, ci_fn_arch, init_key, mesh, rules, pd.component_init
-    )
+    decomposition = init_decomposition(model, ci_fn_arch, init_key, mesh, rules, pd.component_init)
     components, ci_fn = decomposition.components, decomposition.ci_fn
     if pd.component_update_scaling == "c_covariant_balanced":
         components, _ = balance_component_stacks(components)

--- a/param_decomp/core/run_state.py
+++ b/param_decomp/core/run_state.py
@@ -8,7 +8,8 @@ optimizer-state structure.
 """
 
 from collections.abc import Callable
-from typing import NamedTuple
+from functools import partial
+from typing import Literal, NamedTuple
 
 import equinox as eqx
 import jax
@@ -20,8 +21,12 @@ from jax.typing import ArrayLike
 from jaxtyping import Array, PRNGKeyArray
 
 from param_decomp.core.adversary import PersistentAdversary, init_sources_adam_state
-from param_decomp.core.ci_fn import ChunkwiseTransformerCIArch, CIFnArch
-from param_decomp.core.components import ComponentStacks
+from param_decomp.core.ci_fn import (
+    ChunkwiseTransformerCIArch,
+    CIFnArch,
+    pin_ci_head_null_tail,
+)
+from param_decomp.core.components import ComponentStacks, init_component_stacks
 from param_decomp.core.configs import (
     AdamPGDConfig,
     AdamWOptimizerConfig,
@@ -32,6 +37,7 @@ from param_decomp.core.configs import (
 from param_decomp.core.init_placed import (
     init_ci_fn_placed,
     init_component_stacks_placed,
+    init_component_stacks_svd_null_tail_placed,
     init_sources_sharded,
 )
 from param_decomp.core.losses import scheduled_value_traced
@@ -337,21 +343,39 @@ def build_optimizers(pd: PDConfig, ci_fn_arch: CIFnArch, mesh: Mesh | None):
     return opt_vu, opt_ci, (sched_vu, sched_ci)
 
 
+def _frozen_site_weights(model: DecomposedModel) -> dict[str, Array]:
+    """The frozen weights in `weight_deltas` orientation (`[d_out, d_in]` per site),
+    recovered generically as `weight_deltas(vu=0) == W − 0`."""
+    abstract = eqx.filter_eval_shape(partial(init_component_stacks, model.sites), random.key(0))
+    zero_vu = jax.tree.map(lambda leaf: jnp.zeros(leaf.shape, leaf.dtype), abstract)
+    return model.weight_deltas(zero_vu)
+
+
 def init_decomposition(
     model: DecomposedModel,
     ci_fn_arch: CIFnArch,
     init_key: PRNGKeyArray,
     mesh: Mesh,
     rules: PlacementRules,
+    component_init: Literal["random", "svd_null_tail"] = "random",
 ) -> Decomposition:
     """The trained-product half of `init_train_state`, factored out so a consumer can
     `jax.eval_shape` it to recover the saved `decomposition` item's tree structure
-    without building (or knowing about) the optimizers/adversaries."""
+    without building (or knowing about) the optimizers/adversaries. `component_init`
+    changes values only, never the tree structure, so eval-shape consumers may leave it
+    defaulted."""
     ci_key = random.fold_in(init_key, 1)
     # V/U placement derives from the rules table; the CI fn still declares its own
     # per-leaf shardings (PLACEMENT_DESIGN.md migration stage 3).
-    components = init_component_stacks_placed(model.sites, init_key, rules)
     ci_fn = init_ci_fn_placed(ci_fn_arch, model.sites, ci_key, mesh)
+    match component_init:
+        case "random":
+            components = init_component_stacks_placed(model.sites, init_key, rules)
+        case "svd_null_tail":
+            components = init_component_stacks_svd_null_tail_placed(
+                model.sites, _frozen_site_weights(model), init_key, rules
+            )
+            ci_fn = pin_ci_head_null_tail(ci_fn, model.sites)
     assert ci_fn.has_position_axis == model.has_position_axis, (
         f"CI fn has_position_axis={ci_fn.has_position_axis} but model declares "
         f"{model.has_position_axis}"
@@ -375,7 +399,9 @@ def init_train_state(
     assert isinstance(positions, Positioned) == model.has_position_axis, (
         f"{positions} does not match the model's has_position_axis={model.has_position_axis}"
     )
-    decomposition = init_decomposition(model, ci_fn_arch, init_key, mesh, rules)
+    decomposition = init_decomposition(
+        model, ci_fn_arch, init_key, mesh, rules, pd.component_init
+    )
     components, ci_fn = decomposition.components, decomposition.ci_fn
     if pd.component_update_scaling == "c_covariant_balanced":
         components, _ = balance_component_stacks(components)

--- a/param_decomp/core/slot_surgery.py
+++ b/param_decomp/core/slot_surgery.py
@@ -1,0 +1,354 @@
+"""Pure lifecycle surgery primitives for capacity birth / column probes (task #820).
+
+Everything here is a pure function on `(TrainState, site, slot)` — no run-loop, config,
+or model coupling. The caller (the #811 controller harness) supplies the per-site
+represented-matrix reconstruction gradient `G_s = d r_adv / d M_s` for direction
+selection; the recommended zero-plumbing probe is documented on
+`birth_direction_from_grad`. Spec: lore
+2026-08-02--design--reconstruction-budget-control-and-demand-triggered-capacity-birth
+(+ the column-generation addendum). Fail-closed everywhere: unsupported CI
+architectures and optimizer states raise, they never no-op.
+"""
+
+from dataclasses import dataclass
+
+import jax.numpy as jnp
+import optax
+from jaxtyping import Array, Float
+
+from param_decomp.core.ci_fn import CIFn, GlobalMLPCIFn, LayerwiseMLPCIFn
+from param_decomp.core.components import ComponentStacks
+from param_decomp.core.train import Decomposition, TrainingItem, TrainState
+
+# ----------------------------- slot discovery -----------------------------
+
+
+def find_inactive_slot(components: ComponentStacks, site: str) -> int | None:
+    """Lowest slot whose U row is EXACTLY zero (the exact-null convention of
+    svd_null_tail and of post-rollback slots). None when the site is full — the
+    controller's CAPACITY_EXHAUSTED input, never an exception."""
+    _, U = components.site(site)
+    null_rows = jnp.all(U == 0.0, axis=1)
+    idx = int(jnp.argmax(null_rows))
+    return idx if bool(null_rows[idx]) else None
+
+
+# ----------------------------- birth direction -----------------------------
+
+
+def birth_direction_from_grad(
+    G: Float[Array, "d_in d_out"], n_iters: int = 64
+) -> tuple[Array, Array]:
+    """Leading left singular direction `p` (unit) and value `sigma` of the represented-
+    matrix gradient `G = d r_adv / d M_s` — the GradMax-optimal rank-1 birth direction:
+    with `V[:, c] = p, U[c, :] = 0` the represented matrix is unchanged exactly, while
+    `d r_adv / d U[c, :] = p^T G = sigma q^T` has the maximum first-order norm among
+    unit-norm choices of the live factor.
+
+    How the caller gets `G` with zero model plumbing: for a null slot (`U_c = 0`),
+    `dL/dU_c` evaluated at the unperturbed function with `V_c = v` and the slot's mask
+    forced 1 equals `v^T G`; symmetrically `dL/dV_c` at `V_c = 0, U_c = u` equals
+    `G u` — so 2–3 alternating probe backwards on one scratch slot power-iterate the
+    same pair this function computes, when materializing `G` is too big. Here `G` is
+    per-site (`d_in x d_out`), small in every current target, so we take it directly."""
+    G = G.astype(jnp.float32)
+    v = jnp.ones((G.shape[1],), jnp.float32) / jnp.sqrt(G.shape[1])
+    for _ in range(n_iters):
+        p = G @ v
+        p = p / (jnp.linalg.norm(p) + 1e-30)
+        v = G.T @ p
+        sigma = jnp.linalg.norm(v)
+        v = v / (sigma + 1e-30)
+    return p, sigma
+
+
+def select_birth_site(grads_by_site: dict[str, Array]) -> tuple[str, Array, Array]:
+    """The site with the largest leading singular value of its represented-matrix
+    gradient, normalized by sqrt(numel) so heterogeneous site shapes compare fairly.
+    Returns `(site, p, sigma)`."""
+    assert grads_by_site, "no candidate sites"
+    best: tuple[str, Array, Array] | None = None
+    best_score = -jnp.inf
+    for site, G in grads_by_site.items():
+        p, sigma = birth_direction_from_grad(G)
+        score = sigma / jnp.sqrt(jnp.asarray(G.size, jnp.float32))
+        if bool(score > best_score):
+            best, best_score = (site, p, sigma), score
+    assert best is not None
+    return best
+
+
+# ----------------------------- state surgery -----------------------------
+
+
+def _edited_stacks(
+    components: ComponentStacks, site: str, slot: int, v_col: Array, u_row: Array
+) -> ComponentStacks:
+    shape, stack_idx = {name: (s, i) for name, s, i in components.site_slots}[site]
+    Vs, Us = components.stacks[shape]
+    assert 0 <= slot < Vs.shape[2], (slot, Vs.shape)
+    new_stacks = dict(components.stacks)
+    new_stacks[shape] = (
+        Vs.at[stack_idx, :, slot].set(v_col.astype(Vs.dtype)),
+        Us.at[stack_idx, slot, :].set(u_row.astype(Us.dtype)),
+    )
+    return ComponentStacks(stacks=new_stacks, site_slots=components.site_slots)
+
+
+def _ci_head_leaves(ci_fn: CIFn, site: str) -> tuple[Array, Array, int]:
+    """(final weights, final bias, column offset of `site` slot 0) — the two leaves CI
+    surgery edits. Fail-closed on any other architecture."""
+    match ci_fn:
+        case LayerwiseMLPCIFn():
+            mlp = ci_fn.site_mlps[site]
+            return mlp.weights[-1], mlp.biases[-1], 0
+        case GlobalMLPCIFn():
+            offset = 0
+            for name, c in zip(ci_fn.output_names, ci_fn.c_sizes, strict=True):
+                if name == site:
+                    return ci_fn.mlp.weights[-1], ci_fn.mlp.biases[-1], offset
+                offset += c
+            raise AssertionError(f"site {site!r} not in {ci_fn.output_names}")
+        case _:
+            raise NotImplementedError(
+                f"slot surgery supports the MLP CI fns only, not {type(ci_fn).__name__}"
+            )
+
+
+def _with_ci_head(ci_fn: CIFn, site: str, weights: Array, bias: Array) -> CIFn:
+    import equinox as eqx
+
+    match ci_fn:
+        case LayerwiseMLPCIFn():
+            return eqx.tree_at(
+                lambda f: (f.site_mlps[site].weights[-1], f.site_mlps[site].biases[-1]),
+                ci_fn,
+                (weights, bias),
+            )
+        case GlobalMLPCIFn():
+            return eqx.tree_at(
+                lambda f: (f.mlp.weights[-1], f.mlp.biases[-1]), ci_fn, (weights, bias)
+            )
+        case _:
+            raise NotImplementedError(type(ci_fn).__name__)
+
+
+@dataclass(frozen=True)
+class TrialSnapshot:
+    """Everything a COLUMN_PROBE rollback needs to restore, captured before surgery:
+    the slot's factor slices, CI-head column/bias entry, and the corresponding Adam
+    moment slices in both optimizers. Restore is bitwise (`rollback_trial`)."""
+
+    site: str
+    slot: int
+    v_col: Array
+    u_row: Array
+    ci_w_col: Array
+    ci_b: Array
+    vu_mu_v: Array
+    vu_mu_u: Array
+    vu_nu_v: Array
+    vu_nu_u: Array
+    ci_mu_w_col: Array
+    ci_mu_b: Array
+    ci_nu_w_col: Array
+    ci_nu_b: Array
+
+
+def _slot_slices(components_like: ComponentStacks, site: str, slot: int) -> tuple[Array, Array]:
+    V, U = components_like.site(site)
+    return V[:, slot], U[slot, :]
+
+
+def _adam_state(opt_state) -> optax.ScaleByAdamState:
+    holder: list[optax.ScaleByAdamState] = []
+
+    def visit(node):
+        if isinstance(node, optax.ScaleByAdamState):
+            holder.append(node)
+        elif type(node) is tuple:
+            for x in node:
+                visit(x)
+
+    visit(opt_state)
+    assert len(holder) == 1, f"expected exactly one ScaleByAdamState, found {len(holder)}"
+    return holder[0]
+
+
+def snapshot_trial(state: TrainState, site: str, slot: int) -> TrialSnapshot:
+    components = state.decomposition.components
+    ci_w, ci_b, offset = _ci_head_leaves(state.decomposition.ci_fn, site)
+    col = offset + slot
+    vu_adam = _adam_state(state.training.components_opt_state)
+    ci_adam = _adam_state(state.training.ci_fn_opt_state)
+    mu_v, mu_u = _slot_slices(vu_adam.mu, site, slot)
+    nu_v, nu_u = _slot_slices(vu_adam.nu, site, slot)
+    ci_mu_w, ci_mu_b, _ = _ci_head_leaves_like(ci_adam.mu, state.decomposition.ci_fn, site)
+    ci_nu_w, ci_nu_b, _ = _ci_head_leaves_like(ci_adam.nu, state.decomposition.ci_fn, site)
+    v_col, u_row = _slot_slices(components, site, slot)
+    return TrialSnapshot(
+        site=site, slot=slot,
+        v_col=v_col, u_row=u_row,
+        ci_w_col=ci_w[:, col], ci_b=ci_b[col],
+        vu_mu_v=mu_v, vu_mu_u=mu_u, vu_nu_v=nu_v, vu_nu_u=nu_u,
+        ci_mu_w_col=ci_mu_w[:, col], ci_mu_b=ci_mu_b[col],
+        ci_nu_w_col=ci_nu_w[:, col], ci_nu_b=ci_nu_b[col],
+    )  # fmt: skip
+
+
+def _ci_head_leaves_like(tree, ci_fn: CIFn, site: str) -> tuple[Array, Array, int]:
+    """The final-layer leaves of a CI-fn-SHAPED tree (an Adam moment tree), located via
+    the same structure as `_ci_head_leaves`."""
+    match ci_fn:
+        case LayerwiseMLPCIFn():
+            return tree.site_mlps[site].weights[-1], tree.site_mlps[site].biases[-1], 0
+        case GlobalMLPCIFn():
+            offset = 0
+            for name, c in zip(ci_fn.output_names, ci_fn.c_sizes, strict=True):
+                if name == site:
+                    return tree.mlp.weights[-1], tree.mlp.biases[-1], offset
+                offset += c
+            raise AssertionError(site)
+        case _:
+            raise NotImplementedError(type(ci_fn).__name__)
+
+
+def _edit_slot_everywhere(
+    state: TrainState,
+    site: str,
+    slot: int,
+    v_col: Array,
+    u_row: Array,
+    ci_w_col: Array,
+    ci_b_val: Array,
+    vu_moments: tuple[Array, Array, Array, Array],
+    ci_moments: tuple[Array, Array, Array, Array],
+) -> TrainState:
+    """Write the slot's factor slices, CI-head column/bias, and Adam-moment slices —
+    the ONE mutation path shared by birth and rollback so they cannot drift apart.
+    `vu_moments = (mu_v, mu_u, nu_v, nu_u)`, `ci_moments = (mu_w_col, mu_b, nu_w_col, nu_b)`."""
+    import equinox as eqx
+
+    decomposition = state.decomposition
+    ci_fn = decomposition.ci_fn
+    ci_w, ci_b, offset = _ci_head_leaves(ci_fn, site)
+    col = offset + slot
+
+    new_components = _edited_stacks(decomposition.components, site, slot, v_col, u_row)
+    new_ci = _with_ci_head(
+        ci_fn, site,
+        ci_w.at[:, col].set(ci_w_col.astype(ci_w.dtype)),
+        ci_b.at[col].set(jnp.asarray(ci_b_val, ci_b.dtype)),
+    )  # fmt: skip
+
+    mu_v, mu_u, nu_v, nu_u = vu_moments
+    ci_mu_w, ci_mu_b, ci_nu_w, ci_nu_b = ci_moments
+
+    vu_adam = _adam_state(state.training.components_opt_state)
+    new_vu_opt = _replace_adam(
+        state.training.components_opt_state,
+        vu_adam._replace(
+            mu=_edited_stacks(vu_adam.mu, site, slot, mu_v, mu_u),
+            nu=_edited_stacks(vu_adam.nu, site, slot, nu_v, nu_u),
+        ),
+    )
+
+    def edit_ci_moment_tree(tree, w_col: Array, b_val: Array):
+        w, b, off = _ci_head_leaves_like(tree, ci_fn, site)
+        new_w = w.at[:, off + slot].set(w_col.astype(w.dtype))
+        new_b = b.at[off + slot].set(jnp.asarray(b_val, b.dtype))
+        match ci_fn:
+            case LayerwiseMLPCIFn():
+                return eqx.tree_at(
+                    lambda t: (t.site_mlps[site].weights[-1], t.site_mlps[site].biases[-1]),
+                    tree, (new_w, new_b),
+                )  # fmt: skip
+            case GlobalMLPCIFn():
+                return eqx.tree_at(
+                    lambda t: (t.mlp.weights[-1], t.mlp.biases[-1]), tree, (new_w, new_b)
+                )
+            case _:
+                raise NotImplementedError(type(ci_fn).__name__)
+
+    ci_adam = _adam_state(state.training.ci_fn_opt_state)
+    new_ci_opt = _replace_adam(
+        state.training.ci_fn_opt_state,
+        ci_adam._replace(
+            mu=edit_ci_moment_tree(ci_adam.mu, ci_mu_w, ci_mu_b),
+            nu=edit_ci_moment_tree(ci_adam.nu, ci_nu_w, ci_nu_b),
+        ),
+    )
+
+    return TrainState(
+        decomposition=Decomposition(components=new_components, ci_fn=new_ci),
+        training=TrainingItem(
+            components_opt_state=new_vu_opt,
+            ci_fn_opt_state=new_ci_opt,
+            adversaries=state.training.adversaries,
+            step=state.training.step,
+        ),
+    )
+
+
+def _replace_adam(opt_state, new_adam: optax.ScaleByAdamState):
+    replaced = 0
+
+    def rewrite(node):
+        nonlocal replaced
+        if isinstance(node, optax.ScaleByAdamState):
+            replaced += 1
+            return new_adam
+        if type(node) is tuple:
+            return tuple(rewrite(x) for x in node)
+        return node
+
+    out = rewrite(opt_state)
+    assert replaced == 1, replaced
+    return out
+
+
+def birth_slot(state: TrainState, site: str, slot: int, direction: Array) -> TrainState:
+    """Function-preserving GradMax birth: `V[:, slot] = direction` (unit-norm asserted),
+    `U[slot, :] = 0` — the represented matrix is unchanged exactly — with the slot's
+    CI-head column zeroed, its bias set to 1 (open after protection), and the slot's
+    Adam moments in BOTH optimizers reset to zero (a newborn carries no history).
+    Gate protection during settling is the caller's job via `protected_mask` +
+    `StepControls`."""
+    V, _ = state.decomposition.components.site(site)
+    assert direction.shape == (V.shape[0],), (direction.shape, V.shape)
+    norm = jnp.linalg.norm(direction.astype(jnp.float32))
+    assert bool(jnp.isfinite(norm)) and float(norm) > 0.0
+    unit = direction.astype(jnp.float32) / norm
+    _, U = state.decomposition.components.site(site)
+    assert bool(jnp.all(U[slot, :] == 0.0)), f"slot {slot} of {site} is not an exact null"
+    ci_w, _, _ = _ci_head_leaves(state.decomposition.ci_fn, site)
+    zeros_w = jnp.zeros_like(ci_w[:, 0])
+    zero = jnp.zeros(())
+    return _edit_slot_everywhere(
+        state, site, slot,
+        v_col=unit, u_row=jnp.zeros((U.shape[1],)),
+        ci_w_col=zeros_w, ci_b_val=jnp.ones(()),
+        vu_moments=(jnp.zeros_like(unit), jnp.zeros((U.shape[1],)),
+                    jnp.zeros_like(unit), jnp.zeros((U.shape[1],))),
+        ci_moments=(zeros_w, zero, zeros_w, zero),
+    )  # fmt: skip
+
+
+def rollback_trial(state: TrainState, snapshot: TrialSnapshot) -> TrainState:
+    """Bitwise restore of everything `birth_slot` (and subsequent training of the slot)
+    touched: factor slices, CI-head column/bias, and both optimizers' moment slices."""
+    return _edit_slot_everywhere(
+        state, snapshot.site, snapshot.slot,
+        v_col=snapshot.v_col, u_row=snapshot.u_row,
+        ci_w_col=snapshot.ci_w_col, ci_b_val=snapshot.ci_b,
+        vu_moments=(snapshot.vu_mu_v, snapshot.vu_mu_u, snapshot.vu_nu_v, snapshot.vu_nu_u),
+        ci_moments=(snapshot.ci_mu_w_col, snapshot.ci_mu_b,
+                    snapshot.ci_nu_w_col, snapshot.ci_nu_b),
+    )  # fmt: skip
+
+
+def protected_mask(components: ComponentStacks, site: str, slot: int) -> dict[str, Array]:
+    """The `StepControls.protected` entry holding exactly this slot's gate open."""
+    _, U = components.site(site)
+    C = U.shape[0]
+    return {site: jnp.zeros((C,), bool).at[slot].set(True)}

--- a/param_decomp/core/slot_surgery.py
+++ b/param_decomp/core/slot_surgery.py
@@ -352,3 +352,27 @@ def protected_mask(components: ComponentStacks, site: str, slot: int) -> dict[st
     _, U = components.site(site)
     C = U.shape[0]
     return {site: jnp.zeros((C,), bool).at[slot].set(True)}
+
+
+def truncate_active_prefix(state: TrainState, active_by_site: dict[str, int]) -> TrainState:
+    """Turn every slot at or beyond `active_by_site[site]` into an exact inactive null:
+    U row zero, CI-head column zero with bias 0 (closed, NOT protected-open — these are
+    dead capacity, not newborns), and the slot's Adam moments cleared in both
+    optimizers. V columns keep their values (null-ness is defined by the U row; see
+    `find_inactive_slot`). Idempotent. This is how an acceptance case authors
+    'physical Cmax with a smaller logical active width' without a second initializer."""
+    for site, k in active_by_site.items():
+        V, U = state.decomposition.components.site(site)
+        assert 0 < k <= U.shape[0], (site, k, U.shape)
+        zeros_w = jnp.zeros_like(_ci_head_leaves(state.decomposition.ci_fn, site)[0][:, 0])
+        zero = jnp.zeros(())
+        for slot in range(k, U.shape[0]):
+            state = _edit_slot_everywhere(
+                state, site, slot,
+                v_col=V[:, slot], u_row=jnp.zeros((U.shape[1],)),
+                ci_w_col=zeros_w, ci_b_val=zero,
+                vu_moments=(jnp.zeros((V.shape[0],)), jnp.zeros((U.shape[1],)),
+                            jnp.zeros((V.shape[0],)), jnp.zeros((U.shape[1],))),
+                ci_moments=(zeros_w, zero, zeros_w, zero),
+            )  # fmt: skip
+    return state

--- a/param_decomp/core/slot_surgery.py
+++ b/param_decomp/core/slot_surgery.py
@@ -11,6 +11,7 @@ architectures and optimizer states raise, they never no-op.
 """
 
 from dataclasses import dataclass
+from typing import Any, cast
 
 import jax.numpy as jnp
 import optax
@@ -51,12 +52,14 @@ def birth_direction_from_grad(
     `G u` — so 2–3 alternating probe backwards on one scratch slot power-iterate the
     same pair this function computes, when materializing `G` is too big. Here At LM scale
     use that alternating factor-gradient path rather than materializing dense `G`."""
-    G = G.astype(jnp.float32)
-    v = jnp.ones((G.shape[1],), jnp.float32) / jnp.sqrt(G.shape[1])
+    g = G.astype(jnp.float32)
+    v = jnp.ones((g.shape[1],), jnp.float32) / jnp.sqrt(g.shape[1])
+    p = g @ v
+    sigma = jnp.linalg.norm(p)
     for _ in range(n_iters):
-        p = G @ v
+        p = g @ v
         p = p / (jnp.linalg.norm(p) + 1e-30)
-        v = G.T @ p
+        v = g.T @ p
         sigma = jnp.linalg.norm(v)
         v = v / (sigma + 1e-30)
     return p, sigma
@@ -156,10 +159,10 @@ def rollback_trial(snapshot: TrialSnapshot) -> TrainState:
     return snapshot.state
 
 
-def _adam_state(opt_state) -> optax.ScaleByAdamState:
+def _adam_state(opt_state: Any) -> optax.ScaleByAdamState:
     holder: list[optax.ScaleByAdamState] = []
 
-    def visit(node):
+    def visit(node: Any) -> None:
         if isinstance(node, optax.ScaleByAdamState):
             holder.append(node)
         elif type(node) is tuple:
@@ -171,7 +174,7 @@ def _adam_state(opt_state) -> optax.ScaleByAdamState:
     return holder[0]
 
 
-def _ci_head_leaves_like(tree, ci_fn: CIFn, site: str) -> tuple[Array, Array, int]:
+def _ci_head_leaves_like(tree: Any, ci_fn: CIFn, site: str) -> tuple[Array, Array, int]:
     """The final-layer leaves of a CI-fn-SHAPED tree (an Adam moment tree), located via
     the same structure as `_ci_head_leaves`."""
     match ci_fn:
@@ -223,12 +226,12 @@ def _edit_slot_everywhere(
     new_vu_opt = _replace_adam(
         state.training.components_opt_state,
         vu_adam._replace(
-            mu=_edited_stacks(vu_adam.mu, site, slot, mu_v, mu_u),
-            nu=_edited_stacks(vu_adam.nu, site, slot, nu_v, nu_u),
+            mu=_edited_stacks(cast(ComponentStacks, cast(object, vu_adam.mu)), site, slot, mu_v, mu_u),
+            nu=_edited_stacks(cast(ComponentStacks, cast(object, vu_adam.nu)), site, slot, nu_v, nu_u),
         ),
     )
 
-    def edit_ci_moment_tree(tree, w_col: Array, b_val: Array):
+    def edit_ci_moment_tree(tree: Any, w_col: Array, b_val: Array) -> Any:
         w, b, off = _ci_head_leaves_like(tree, ci_fn, site)
         new_w = w.at[:, off + slot].set(w_col.astype(w.dtype))
         new_b = b.at[off + slot].set(jnp.asarray(b_val, b.dtype))
@@ -265,10 +268,10 @@ def _edit_slot_everywhere(
     )
 
 
-def _replace_adam(opt_state, new_adam: optax.ScaleByAdamState):
+def _replace_adam(opt_state: Any, new_adam: optax.ScaleByAdamState) -> Any:
     replaced = 0
 
-    def rewrite(node):
+    def rewrite(node: Any) -> Any:
         nonlocal replaced
         if isinstance(node, optax.ScaleByAdamState):
             replaced += 1

--- a/param_decomp/core/slot_surgery.py
+++ b/param_decomp/core/slot_surgery.py
@@ -226,8 +226,12 @@ def _edit_slot_everywhere(
     new_vu_opt = _replace_adam(
         state.training.components_opt_state,
         vu_adam._replace(
-            mu=_edited_stacks(cast(ComponentStacks, cast(object, vu_adam.mu)), site, slot, mu_v, mu_u),
-            nu=_edited_stacks(cast(ComponentStacks, cast(object, vu_adam.nu)), site, slot, nu_v, nu_u),
+            mu=_edited_stacks(
+                cast(ComponentStacks, cast(object, vu_adam.mu)), site, slot, mu_v, mu_u
+            ),
+            nu=_edited_stacks(
+                cast(ComponentStacks, cast(object, vu_adam.nu)), site, slot, nu_v, nu_u
+            ),
         ),
     )
 

--- a/param_decomp/core/slot_surgery.py
+++ b/param_decomp/core/slot_surgery.py
@@ -49,8 +49,8 @@ def birth_direction_from_grad(
     `dL/dU_c` evaluated at the unperturbed function with `V_c = v` and the slot's mask
     forced 1 equals `v^T G`; symmetrically `dL/dV_c` at `V_c = 0, U_c = u` equals
     `G u` — so 2–3 alternating probe backwards on one scratch slot power-iterate the
-    same pair this function computes, when materializing `G` is too big. Here `G` is
-    per-site (`d_in x d_out`), small in every current target, so we take it directly."""
+    same pair this function computes, when materializing `G` is too big. Here At LM scale
+    use that alternating factor-gradient path rather than materializing dense `G`."""
     G = G.astype(jnp.float32)
     v = jnp.ones((G.shape[1],), jnp.float32) / jnp.sqrt(G.shape[1])
     for _ in range(n_iters):
@@ -135,29 +135,25 @@ def _with_ci_head(ci_fn: CIFn, site: str, weights: Array, bias: Array) -> CIFn:
 
 @dataclass(frozen=True)
 class TrialSnapshot:
-    """Everything a COLUMN_PROBE rollback needs to restore, captured before surgery:
-    the slot's factor slices, CI-head column/bias entry, and the corresponding Adam
-    moment slices in both optimizers. Restore is bitwise (`rollback_trial`)."""
+    """The ENTIRE immutable pre-trial `TrainState` plus the trial's identity. During a
+    COLUMN_PROBE every other parameter, both optimizers' moments, and the persistent
+    adversaries keep training — restoring only the trial slot would accept/reject on
+    contaminated state, so rollback returns to the full pre-probe frontier. JAX arrays
+    are immutable, so holding the state IS the snapshot (no copies)."""
 
+    state: TrainState
     site: str
     slot: int
-    v_col: Array
-    u_row: Array
-    ci_w_col: Array
-    ci_b: Array
-    vu_mu_v: Array
-    vu_mu_u: Array
-    vu_nu_v: Array
-    vu_nu_u: Array
-    ci_mu_w_col: Array
-    ci_mu_b: Array
-    ci_nu_w_col: Array
-    ci_nu_b: Array
 
 
-def _slot_slices(components_like: ComponentStacks, site: str, slot: int) -> tuple[Array, Array]:
-    V, U = components_like.site(site)
-    return V[:, slot], U[slot, :]
+def snapshot_trial(state: TrainState, site: str, slot: int) -> TrialSnapshot:
+    return TrialSnapshot(state=state, site=site, slot=slot)
+
+
+def rollback_trial(snapshot: TrialSnapshot) -> TrainState:
+    """Bitwise return to the pre-trial frontier: every leaf of the snapshot's state —
+    all V/U, the whole CI fn, both optimizer states, adversaries, and the step counter."""
+    return snapshot.state
 
 
 def _adam_state(opt_state) -> optax.ScaleByAdamState:
@@ -173,27 +169,6 @@ def _adam_state(opt_state) -> optax.ScaleByAdamState:
     visit(opt_state)
     assert len(holder) == 1, f"expected exactly one ScaleByAdamState, found {len(holder)}"
     return holder[0]
-
-
-def snapshot_trial(state: TrainState, site: str, slot: int) -> TrialSnapshot:
-    components = state.decomposition.components
-    ci_w, ci_b, offset = _ci_head_leaves(state.decomposition.ci_fn, site)
-    col = offset + slot
-    vu_adam = _adam_state(state.training.components_opt_state)
-    ci_adam = _adam_state(state.training.ci_fn_opt_state)
-    mu_v, mu_u = _slot_slices(vu_adam.mu, site, slot)
-    nu_v, nu_u = _slot_slices(vu_adam.nu, site, slot)
-    ci_mu_w, ci_mu_b, _ = _ci_head_leaves_like(ci_adam.mu, state.decomposition.ci_fn, site)
-    ci_nu_w, ci_nu_b, _ = _ci_head_leaves_like(ci_adam.nu, state.decomposition.ci_fn, site)
-    v_col, u_row = _slot_slices(components, site, slot)
-    return TrialSnapshot(
-        site=site, slot=slot,
-        v_col=v_col, u_row=u_row,
-        ci_w_col=ci_w[:, col], ci_b=ci_b[col],
-        vu_mu_v=mu_v, vu_mu_u=mu_u, vu_nu_v=nu_v, vu_nu_u=nu_u,
-        ci_mu_w_col=ci_mu_w[:, col], ci_mu_b=ci_mu_b[col],
-        ci_nu_w_col=ci_nu_w[:, col], ci_nu_b=ci_nu_b[col],
-    )  # fmt: skip
 
 
 def _ci_head_leaves_like(tree, ci_fn: CIFn, site: str) -> tuple[Array, Array, int]:
@@ -331,19 +306,6 @@ def birth_slot(state: TrainState, site: str, slot: int, direction: Array) -> Tra
         vu_moments=(jnp.zeros_like(unit), jnp.zeros((U.shape[1],)),
                     jnp.zeros_like(unit), jnp.zeros((U.shape[1],))),
         ci_moments=(zeros_w, zero, zeros_w, zero),
-    )  # fmt: skip
-
-
-def rollback_trial(state: TrainState, snapshot: TrialSnapshot) -> TrainState:
-    """Bitwise restore of everything `birth_slot` (and subsequent training of the slot)
-    touched: factor slices, CI-head column/bias, and both optimizers' moment slices."""
-    return _edit_slot_everywhere(
-        state, snapshot.site, snapshot.slot,
-        v_col=snapshot.v_col, u_row=snapshot.u_row,
-        ci_w_col=snapshot.ci_w_col, ci_b_val=snapshot.ci_b,
-        vu_moments=(snapshot.vu_mu_v, snapshot.vu_mu_u, snapshot.vu_nu_v, snapshot.vu_nu_u),
-        ci_moments=(snapshot.ci_mu_w_col, snapshot.ci_mu_b,
-                    snapshot.ci_nu_w_col, snapshot.ci_nu_b),
     )  # fmt: skip
 
 

--- a/param_decomp/core/slot_surgery.py
+++ b/param_decomp/core/slot_surgery.py
@@ -13,6 +13,7 @@ architectures and optimizer states raise, they never no-op.
 from dataclasses import dataclass
 from typing import Any, cast
 
+import jax
 import jax.numpy as jnp
 import optax
 from jaxtyping import Array, Float
@@ -138,11 +139,13 @@ def _with_ci_head(ci_fn: CIFn, site: str, weights: Array, bias: Array) -> CIFn:
 
 @dataclass(frozen=True)
 class TrialSnapshot:
-    """The ENTIRE immutable pre-trial `TrainState` plus the trial's identity. During a
-    COLUMN_PROBE every other parameter, both optimizers' moments, and the persistent
-    adversaries keep training — restoring only the trial slot would accept/reject on
-    contaminated state, so rollback returns to the full pre-probe frontier. JAX arrays
-    are immutable, so holding the state IS the snapshot (no copies)."""
+    """The ENTIRE pre-trial `TrainState` (independently-owned buffers) plus the trial's
+    identity. During a COLUMN_PROBE every other parameter, both optimizers' moments, and
+    the persistent adversaries keep training — restoring only the trial slot would
+    accept/reject on contaminated state, so rollback returns to the full pre-probe
+    frontier. The buffers are COPIES: immutability alone is not a snapshot under the
+    train step's buffer donation, which deletes the referenced buffers on the next
+    step (found live in the first acceptance run)."""
 
     state: TrainState
     site: str
@@ -150,7 +153,12 @@ class TrialSnapshot:
 
 
 def snapshot_trial(state: TrainState, site: str, slot: int) -> TrialSnapshot:
-    return TrialSnapshot(state=state, site=site, slot=slot)
+    import equinox as eqx
+
+    owned = jax.tree_util.tree_map(
+        lambda leaf: jnp.copy(leaf) if eqx.is_array(leaf) else leaf, state
+    )
+    return TrialSnapshot(state=owned, site=site, slot=slot)
 
 
 def rollback_trial(snapshot: TrialSnapshot) -> TrainState:

--- a/param_decomp/core/slot_surgery.py
+++ b/param_decomp/core/slot_surgery.py
@@ -353,3 +353,40 @@ def truncate_active_prefix(state: TrainState, active_by_site: dict[str, int]) ->
                 ci_moments=(zeros_w, zero, zeros_w, zero),
             )  # fmt: skip
     return state
+
+
+def birth_directions_from_grad(
+    G: Float[Array, "d_in d_out"], k: int
+) -> tuple[Float[Array, "d_in k"], Float[Array, " k"]]:
+    """Top-k left singular directions of the represented-matrix gradient (columns
+    orthonormal, singular values descending). Selection policy — how many directions
+    deserve a slot — is deliberately the CALLER's: a noise floor here would be the next
+    scale-sensitive knob."""
+    assert 0 < k <= min(G.shape), (k, G.shape)
+    P, s, _ = jnp.linalg.svd(G.astype(jnp.float32), full_matrices=False)
+    return P[:, :k], s[:k]
+
+
+def birth_slots(
+    state: TrainState, site: str, slots: tuple[int, ...], directions: Float[Array, "d_in k"]
+) -> TrainState:
+    """Atomic k-slot GradMax birth: column i of `directions` becomes slot i's live V
+    factor (orthonormal columns asserted — the top-k singular directions qualify by
+    construction), every paired U row stays exactly zero (the represented matrix is
+    unchanged for the WHOLE batch), and only the selected slots' CI-head columns/biases
+    and Adam moments are edited. One `snapshot_trial` covers the batch — the snapshot is
+    the full pre-trial state, so a batched rollback needs nothing extra. Collapses the
+    serial-birth lifecycle horizon from (capacity deficit) x settle to ~deficit/k."""
+    assert len(slots) == len(set(slots)) > 0, slots
+    assert directions.shape[1] == len(slots), (directions.shape, slots)
+    gram = directions.astype(jnp.float32).T @ directions.astype(jnp.float32)
+    assert bool(jnp.allclose(gram, jnp.eye(len(slots)), atol=1e-5)), (
+        "birth directions must be orthonormal (a non-orthogonal batch double-spends "
+        "the same demand direction across slots)"
+    )
+    _, U = state.decomposition.components.site(site)
+    for slot in slots:
+        assert bool(jnp.all(U[slot, :] == 0.0)), f"slot {slot} of {site} is not an exact null"
+    for i, slot in enumerate(slots):
+        state = birth_slot(state, site, slot, directions[:, i])
+    return state

--- a/param_decomp/core/tests/test_controller.py
+++ b/param_decomp/core/tests/test_controller.py
@@ -72,7 +72,7 @@ def test_off_slack_reenters_below_hi() -> None:
     assert a1.state.phase is Phase.OFF and a1.state.hi == 2.0
     a2 = controller_update(a1.state, window(0.0), CFG, 3)  # OFF feasible -> re-enter
     assert a2.state.phase is Phase.CONTROL
-    assert a2.state.log_c < a1.state.hi
+    assert a1.state.hi is not None and a2.state.log_c < a1.state.hi
 
 
 def test_on_target_plateau_fires_column_probe_and_rejection_cools_down() -> None:

--- a/param_decomp/core/tests/test_controller.py
+++ b/param_decomp/core/tests/test_controller.py
@@ -1,0 +1,107 @@
+"""Recon-budget controller state machine: sign correctness, bracketing, OFF state,
+the two lifecycle events, capacity-exhausted reporting, and protection expiry."""
+
+import math
+
+from param_decomp.core.controller import (
+    Action,
+    ControllerConfig,
+    ControllerState,
+    Event,
+    Phase,
+    WindowSummary,
+    controller_update,
+)
+
+CFG = ControllerConfig(tau=0.1, noise_margin=0.01, dwell_windows=2, plateau_rtol=0.02)
+
+
+def window(r_adv: float, complexity: float = 100.0, spare: bool = True) -> WindowSummary:
+    return WindowSummary(r_adv=r_adv, complexity=complexity, spare_slot_exists=spare)
+
+
+def drive(state: ControllerState, windows: list[WindowSummary]) -> list[Action]:
+    actions = []
+    for w in windows:
+        action = controller_update(state, w, CFG, protect_windows=3)
+        actions.append(action)
+        state = action.state
+    return actions
+
+
+def test_violation_drives_c_down_and_slack_up() -> None:
+    s0 = ControllerState.initial(math.log(1.0), CFG)
+    violated = controller_update(s0, window(r_adv=0.5), CFG, protect_windows=3).state
+    assert violated.log_c < s0.log_c
+    slack = controller_update(s0, window(r_adv=0.0), CFG, protect_windows=3).state
+    assert slack.log_c > s0.log_c
+
+
+def test_sign_flip_halves_the_bracketing_step() -> None:
+    s0 = ControllerState.initial(math.log(1.0), CFG)
+    a1 = controller_update(s0, window(0.5), CFG, 3)  # violation
+    a2 = controller_update(a1.state, window(0.0), CFG, 3)  # slack -> flip
+    assert a2.state.log_step == a1.state.log_step / 2
+
+
+def test_exhausted_bracket_under_violation_goes_off_then_feasibility_birth() -> None:
+    state = ControllerState.initial(math.log(1.0), CFG)
+    actions = drive(state, [window(0.5), window(0.0)] * 8 + [window(0.5)] * 6)
+    phases = [a.state.phase for a in actions]
+    assert Phase.OFF in phases
+    events = [a.event for a in actions]
+    assert Event.FEASIBILITY_BIRTH in events
+    birth_idx = events.index(Event.FEASIBILITY_BIRTH)
+    assert phases[birth_idx] is Phase.BIRTH_PROTECTED
+    # dwell was respected: the windows immediately before the birth were OFF + violating
+    assert phases[birth_idx - 1] is Phase.OFF
+
+
+def test_no_birth_while_constraint_is_slack() -> None:
+    state = ControllerState.initial(math.log(1.0), CFG)
+    actions = drive(state, [window(0.0)] * 20)
+    assert all(a.event in (Event.NONE, Event.COLUMN_PROBE) for a in actions)
+    assert Event.FEASIBILITY_BIRTH not in [a.event for a in actions]
+
+
+def test_on_target_plateau_fires_column_probe() -> None:
+    state = ControllerState.initial(math.log(1.0), CFG)
+    # r_adv exactly on tau (within noise margin), complexity flat -> plateau dwell -> probe
+    actions = drive(state, [window(CFG.tau, complexity=50.0)] * 4)
+    assert Event.COLUMN_PROBE in [a.event for a in actions]
+
+
+def test_capacity_exhausted_is_reported_not_clipped() -> None:
+    state = ControllerState.initial(math.log(1.0), CFG)
+    actions = drive(
+        state, [window(CFG.tau, complexity=50.0, spare=False)] * 6
+    )
+    assert Event.CAPACITY_EXHAUSTED in [a.event for a in actions]
+    assert all(a.state.phase is not Phase.BIRTH_PROTECTED for a in actions)
+
+
+def test_protection_expires_back_to_control_with_fresh_bracket() -> None:
+    protected = ControllerState(
+        phase=Phase.BIRTH_PROTECTED,
+        log_c=0.0,
+        log_step=CFG.min_log_step / 4,
+        last_sign=1,
+        dwell=0,
+        prev_complexity=None,
+        protect_windows_left=2,
+    )
+    a1 = controller_update(protected, window(0.5), CFG, 3)
+    assert a1.state.phase is Phase.BIRTH_PROTECTED and a1.event is Event.NONE
+    a2 = controller_update(a1.state, window(0.5), CFG, 3)
+    assert a2.state.phase is Phase.CONTROL
+    assert a2.state.log_step == CFG.initial_log_step  # bracket restarted
+
+
+def test_off_state_c_is_exactly_zero_and_slack_reenters_control() -> None:
+    off = ControllerState(
+        phase=Phase.OFF, log_c=-3.0, log_step=CFG.initial_log_step,
+        last_sign=0, dwell=0, prev_complexity=None, protect_windows_left=0,
+    )  # fmt: skip
+    assert off.c == 0.0
+    back = controller_update(off, window(0.0), CFG, 3).state
+    assert back.phase is Phase.CONTROL and back.c == math.exp(-3.0)

--- a/param_decomp/core/tests/test_controller.py
+++ b/param_decomp/core/tests/test_controller.py
@@ -81,6 +81,10 @@ def test_on_target_plateau_fires_column_probe_and_rejection_cools_down() -> None
     events = [a.event for a in actions]
     assert Event.COLUMN_PROBE in events
     probed = actions[events.index(Event.COLUMN_PROBE)].state
+    assert probed.phase is Phase.PROBE_PENDING
+    # time never ages a pending probe back to control
+    aged = drive(probed, [window(CFG.tau, complexity=50.0)] * 10)
+    assert all(a.state.phase is Phase.PROBE_PENDING for a in aged)
     # rejection -> cooldown suppresses the immediate re-probe
     after = probe_rejected(probed, CFG)
     actions2 = drive(after, [window(CFG.tau, complexity=50.0)] * CFG.probe_cooldown_windows)
@@ -95,14 +99,35 @@ def test_on_target_plateau_fires_column_probe_and_rejection_cools_down() -> None
         assert Event.COLUMN_PROBE not in [a.event for a in actions4]
 
 
-def test_probe_accepted_resets_bracket_and_rejections() -> None:
+def test_probe_accepted_resets_bracket_plateau_and_rejections() -> None:
     state = ControllerState(
-        phase=Phase.BIRTH_PROTECTED, log_c=0.0, lo=-1.0, hi=1.0, dwell=0,
-        prev_complexity=50.0, protect_windows_left=2, probe_cooldown=0, rejected_probes=1,
+        phase=Phase.PROBE_PENDING, log_c=0.0, lo=-1.0, hi=1.0, dwell=0,
+        prev_complexity=50.0, protect_windows_left=0, probe_cooldown=0, rejected_probes=1,
     )  # fmt: skip
     accepted = probe_accepted(state)
     assert accepted.phase is Phase.CONTROL
     assert accepted.lo is None and accepted.hi is None and accepted.rejected_probes == 0
+    assert accepted.prev_complexity is None
+
+
+def test_verdicts_assert_phase_legality() -> None:
+    import pytest
+
+    control = ControllerState.initial(0.0)
+    with pytest.raises(AssertionError):
+        probe_accepted(control)
+    with pytest.raises(AssertionError):
+        probe_rejected(control, CFG)
+
+
+def test_feasibility_protection_expiry_clears_plateau_and_lineage() -> None:
+    state = ControllerState(
+        phase=Phase.BIRTH_PROTECTED, log_c=0.0, lo=-1.0, hi=1.0, dwell=0,
+        prev_complexity=50.0, protect_windows_left=1, probe_cooldown=2, rejected_probes=2,
+    )  # fmt: skip
+    out = controller_update(state, window(0.5), CFG, 3).state
+    assert out.phase is Phase.CONTROL
+    assert out.prev_complexity is None and out.rejected_probes == 0 and out.probe_cooldown == 0
 
 
 def test_capacity_exhausted_is_reported_not_clipped() -> None:

--- a/param_decomp/core/tests/test_controller.py
+++ b/param_decomp/core/tests/test_controller.py
@@ -1,5 +1,5 @@
-"""Recon-budget controller state machine: sign correctness, bracketing, OFF state,
-the two lifecycle events, capacity-exhausted reporting, and protection expiry."""
+"""Recon-budget controller: bracket termination on one-sided signs, bisection, OFF and
+the two lifecycle events, probe cooldown/terminal, capacity-exhausted reporting."""
 
 import math
 
@@ -11,9 +11,14 @@ from param_decomp.core.controller import (
     Phase,
     WindowSummary,
     controller_update,
+    probe_accepted,
+    probe_rejected,
 )
 
-CFG = ControllerConfig(tau=0.1, noise_margin=0.01, dwell_windows=2, plateau_rtol=0.02)
+CFG = ControllerConfig(
+    tau=0.1, noise_margin=0.01, max_log_c=math.log(1e4), dwell_windows=2,
+    probe_cooldown_windows=3, max_rejected_probes=2,
+)  # fmt: skip
 
 
 def window(r_adv: float, complexity: float = 100.0, spare: bool = True) -> WindowSummary:
@@ -29,79 +34,85 @@ def drive(state: ControllerState, windows: list[WindowSummary]) -> list[Action]:
     return actions
 
 
-def test_violation_drives_c_down_and_slack_up() -> None:
-    s0 = ControllerState.initial(math.log(1.0), CFG)
-    violated = controller_update(s0, window(r_adv=0.5), CFG, protect_windows=3).state
-    assert violated.log_c < s0.log_c
-    slack = controller_update(s0, window(r_adv=0.0), CFG, protect_windows=3).state
-    assert slack.log_c > s0.log_c
-
-
-def test_sign_flip_halves_the_bracketing_step() -> None:
-    s0 = ControllerState.initial(math.log(1.0), CFG)
-    a1 = controller_update(s0, window(0.5), CFG, 3)  # violation
-    a2 = controller_update(a1.state, window(0.0), CFG, 3)  # slack -> flip
-    assert a2.state.log_step == a1.state.log_step / 2
-
-
-def test_exhausted_bracket_under_violation_goes_off_then_feasibility_birth() -> None:
-    state = ControllerState.initial(math.log(1.0), CFG)
-    actions = drive(state, [window(0.5), window(0.0)] * 8 + [window(0.5)] * 6)
+def test_all_violation_reaches_off_then_feasibility_birth_in_finite_windows() -> None:
+    state = ControllerState.initial(math.log(1.0))
+    actions = drive(state, [window(0.5)] * 8)
     phases = [a.state.phase for a in actions]
-    assert Phase.OFF in phases
     events = [a.event for a in actions]
+    # first violating window: hi set, no lo -> immediate OFF probe
+    assert phases[0] is Phase.OFF
+    # OFF + sustained violation -> dwell -> birth, all within a handful of windows
     assert Event.FEASIBILITY_BIRTH in events
-    birth_idx = events.index(Event.FEASIBILITY_BIRTH)
-    assert phases[birth_idx] is Phase.BIRTH_PROTECTED
-    # dwell was respected: the windows immediately before the birth were OFF + violating
-    assert phases[birth_idx - 1] is Phase.OFF
+    assert phases[events.index(Event.FEASIBILITY_BIRTH)] is Phase.BIRTH_PROTECTED
 
 
-def test_no_birth_while_constraint_is_slack() -> None:
-    state = ControllerState.initial(math.log(1.0), CFG)
-    actions = drive(state, [window(0.0)] * 20)
-    assert all(a.event in (Event.NONE, Event.COLUMN_PROBE) for a in actions)
+def test_monotone_slack_is_bounded_by_the_guard() -> None:
+    state = ControllerState.initial(math.log(1.0))
+    actions = drive(state, [window(0.0, complexity=c) for c in range(100, 200)])
+    assert max(a.state.log_c for a in actions) <= CFG.max_log_c
     assert Event.FEASIBILITY_BIRTH not in [a.event for a in actions]
 
 
-def test_on_target_plateau_fires_column_probe() -> None:
-    state = ControllerState.initial(math.log(1.0), CFG)
-    # r_adv exactly on tau (within noise margin), complexity flat -> plateau dwell -> probe
+def test_bracket_bisects_to_the_boundary() -> None:
+    # true boundary at log_c = 0: violation iff log_c > 0
+    state = ControllerState.initial(math.log(1.0) + 2.0)
+    for _ in range(40):
+        r = 0.5 if state.log_c > 0 else 0.0
+        out = controller_update(state, window(r), CFG, 3)
+        state = out.state
+        if state.phase is Phase.OFF:  # transient: first window has no lo yet
+            state = controller_update(state, window(0.0), CFG, 3).state
+    assert state.lo is not None and state.hi is not None
+    assert abs(state.lo) < 1.0  # converged near the boundary from either side
+
+
+def test_off_slack_reenters_below_hi() -> None:
+    state = ControllerState.initial(2.0)
+    a1 = controller_update(state, window(0.5), CFG, 3)  # violation, no lo -> OFF
+    assert a1.state.phase is Phase.OFF and a1.state.hi == 2.0
+    a2 = controller_update(a1.state, window(0.0), CFG, 3)  # OFF feasible -> re-enter
+    assert a2.state.phase is Phase.CONTROL
+    assert a2.state.log_c < a1.state.hi
+
+
+def test_on_target_plateau_fires_column_probe_and_rejection_cools_down() -> None:
+    state = ControllerState.initial(0.0)
     actions = drive(state, [window(CFG.tau, complexity=50.0)] * 4)
-    assert Event.COLUMN_PROBE in [a.event for a in actions]
+    events = [a.event for a in actions]
+    assert Event.COLUMN_PROBE in events
+    probed = actions[events.index(Event.COLUMN_PROBE)].state
+    # rejection -> cooldown suppresses the immediate re-probe
+    after = probe_rejected(probed, CFG)
+    actions2 = drive(after, [window(CFG.tau, complexity=50.0)] * CFG.probe_cooldown_windows)
+    assert Event.COLUMN_PROBE not in [a.event for a in actions2]
+    # second rejection at the same plateau -> terminal
+    actions3 = drive(actions2[-1].state, [window(CFG.tau, complexity=50.0)] * 10)
+    events3 = [a.event for a in actions3]
+    if Event.COLUMN_PROBE in events3:
+        after2 = probe_rejected(actions3[events3.index(Event.COLUMN_PROBE)].state, CFG)
+        actions4 = drive(after2, [window(CFG.tau, complexity=50.0)] * 12)
+        assert Event.NO_IMPROVING_COLUMN in [a.event for a in actions4]
+        assert Event.COLUMN_PROBE not in [a.event for a in actions4]
+
+
+def test_probe_accepted_resets_bracket_and_rejections() -> None:
+    state = ControllerState(
+        phase=Phase.BIRTH_PROTECTED, log_c=0.0, lo=-1.0, hi=1.0, dwell=0,
+        prev_complexity=50.0, protect_windows_left=2, probe_cooldown=0, rejected_probes=1,
+    )  # fmt: skip
+    accepted = probe_accepted(state)
+    assert accepted.phase is Phase.CONTROL
+    assert accepted.lo is None and accepted.hi is None and accepted.rejected_probes == 0
 
 
 def test_capacity_exhausted_is_reported_not_clipped() -> None:
-    state = ControllerState.initial(math.log(1.0), CFG)
-    actions = drive(
-        state, [window(CFG.tau, complexity=50.0, spare=False)] * 6
-    )
+    state = ControllerState.initial(0.0)
+    actions = drive(state, [window(CFG.tau, complexity=50.0, spare=False)] * 6)
     assert Event.CAPACITY_EXHAUSTED in [a.event for a in actions]
     assert all(a.state.phase is not Phase.BIRTH_PROTECTED for a in actions)
 
 
-def test_protection_expires_back_to_control_with_fresh_bracket() -> None:
-    protected = ControllerState(
-        phase=Phase.BIRTH_PROTECTED,
-        log_c=0.0,
-        log_step=CFG.min_log_step / 4,
-        last_sign=1,
-        dwell=0,
-        prev_complexity=None,
-        protect_windows_left=2,
-    )
-    a1 = controller_update(protected, window(0.5), CFG, 3)
-    assert a1.state.phase is Phase.BIRTH_PROTECTED and a1.event is Event.NONE
-    a2 = controller_update(a1.state, window(0.5), CFG, 3)
-    assert a2.state.phase is Phase.CONTROL
-    assert a2.state.log_step == CFG.initial_log_step  # bracket restarted
-
-
-def test_off_state_c_is_exactly_zero_and_slack_reenters_control() -> None:
-    off = ControllerState(
-        phase=Phase.OFF, log_c=-3.0, log_step=CFG.initial_log_step,
-        last_sign=0, dwell=0, prev_complexity=None, protect_windows_left=0,
-    )  # fmt: skip
-    assert off.c == 0.0
-    back = controller_update(off, window(0.0), CFG, 3).state
-    assert back.phase is Phase.CONTROL and back.c == math.exp(-3.0)
+def test_no_feasibility_birth_while_slack() -> None:
+    state = ControllerState.initial(0.0)
+    actions = drive(state, [window(0.0)] * 20)
+    assert Event.FEASIBILITY_BIRTH not in [a.event for a in actions]

--- a/param_decomp/core/tests/test_controller.py
+++ b/param_decomp/core/tests/test_controller.py
@@ -164,7 +164,5 @@ def test_complexity_stays_off_through_feasibility_birth_and_protection() -> None
         if a.state.phase is Phase.BIRTH_PROTECTED:
             assert a.state.c == 0.0
     # protection expiry re-enters control BELOW the last known-violating coefficient
-    expiry = next(
-        a.state for a in actions[birth_idx + 1 :] if a.state.phase is Phase.CONTROL
-    )
+    expiry = next(a.state for a in actions[birth_idx + 1 :] if a.state.phase is Phase.CONTROL)
     assert expiry.log_c < actions[birth_idx].state.log_c

--- a/param_decomp/core/tests/test_controller.py
+++ b/param_decomp/core/tests/test_controller.py
@@ -141,3 +141,30 @@ def test_no_feasibility_birth_while_slack() -> None:
     state = ControllerState.initial(0.0)
     actions = drive(state, [window(0.0)] * 20)
     assert Event.FEASIBILITY_BIRTH not in [a.event for a in actions]
+
+
+def test_converged_slack_bracket_still_fires_column_probe() -> None:
+    # boundary between lo and hi with the sampled lo strictly slack (beyond the deadband):
+    # a converged bracket must route into plateau logic, not reset dwell forever
+    state = ControllerState(
+        phase=Phase.CONTROL, log_c=0.0, lo=0.0, hi=0.0 + CFG.resolution / 2, dwell=0,
+        prev_complexity=None, protect_windows_left=0, probe_cooldown=0, rejected_probes=0,
+    )  # fmt: skip
+    actions = drive(state, [window(0.0, complexity=50.0)] * 5)  # r_adv far below tau: slack
+    assert Event.COLUMN_PROBE in [a.event for a in actions]
+
+
+def test_complexity_stays_off_through_feasibility_birth_and_protection() -> None:
+    state = ControllerState.initial(math.log(1.0))
+    actions = drive(state, [window(0.5)] * 10)
+    events = [a.event for a in actions]
+    birth_idx = events.index(Event.FEASIBILITY_BIRTH)
+    assert actions[birth_idx].state.c == 0.0
+    for a in actions[birth_idx + 1 :]:
+        if a.state.phase is Phase.BIRTH_PROTECTED:
+            assert a.state.c == 0.0
+    # protection expiry re-enters control BELOW the last known-violating coefficient
+    expiry = next(
+        a.state for a in actions[birth_idx + 1 :] if a.state.phase is Phase.CONTROL
+    )
+    assert expiry.log_c < actions[birth_idx].state.log_c

--- a/param_decomp/core/tests/test_optim_torch_parity.py
+++ b/param_decomp/core/tests/test_optim_torch_parity.py
@@ -18,9 +18,13 @@ from param_decomp.core.components import component_stacks_from_sites
 from param_decomp.core.configs import AdamWOptimizerConfig, AnyOptimizerConfig, MuonOptimizerConfig
 from param_decomp.core.run_state import (
     _optimizer_with_clip,
+    _transform_adam_moments_to_balanced_gauge,
+    balance_component_stacks,
     clip_by_global_norm_with_eps,
+    gauge_balance_component_optimizer,
     optax_schedule,
     scale_component_updates_c_covariant,
+    scale_component_updates_c_covariant_balanced,
     stacked_muon_dimension_numbers,
 )
 from param_decomp.core.schedule import Knot, ScheduleConfig
@@ -414,6 +418,69 @@ def test_stacked_muon_dim_numbers_fail_closed():
             {"k": jnp.zeros((3, 3, 8, 16))},
             optax.contrib.MuonDimensionNumbers(reduction_axis=-2, output_axis=-1),
         )
+
+
+def test_component_gauge_balance_preserves_each_rank_one_term():
+    V = jnp.array([[[3.0, 0.0, 1.0], [4.0, 0.0, -2.0]]])
+    U = jnp.array([[[12.0, 0.0], [2.0, -1.0], [0.0, 5.0]]])
+    components = component_stacks_from_sites({"site": (V[0], U[0])})
+
+    balanced, _ = balance_component_stacks(components)
+    Vb, Ub = balanced.site("site")
+
+    original_terms = jnp.einsum("ic,co->cio", V[0], U[0])
+    balanced_terms = jnp.einsum("ic,co->cio", Vb, Ub)
+    assert jnp.allclose(original_terms, balanced_terms)
+    non_null = (jnp.linalg.norm(V[0], axis=0) != 0) & (jnp.linalg.norm(U[0], axis=1) != 0)
+    assert jnp.allclose(
+        jnp.linalg.norm(Vb, axis=0)[non_null], jnp.linalg.norm(Ub, axis=1)[non_null]
+    )
+    assert jnp.array_equal(Vb[:, 1], V[0, :, 1])
+    assert jnp.array_equal(Ub[1], U[0, 1])
+
+
+def test_gauge_balanced_adam_retracts_update_and_transforms_moments():
+    params = component_stacks_from_sites(
+        {
+            "site": (
+                jnp.array([[1.0, -2.0], [3.0, 0.5], [-1.0, 4.0]]),
+                jnp.array([[2.0, -1.0], [0.25, 3.0]]),
+            )
+        }
+    )
+    grads = jax.tree.map(lambda x: jnp.arange(x.size, dtype=x.dtype).reshape(x.shape) + 1, params)
+    inner = optax.adamw(1e-2, weight_decay=0.0)
+
+    raw_updates, raw_state = inner.update(grads, inner.init(params), params)
+    raw_proposed = optax.apply_updates(params, raw_updates)
+    expected, scales = balance_component_stacks(raw_proposed)
+    expected_state = _transform_adam_moments_to_balanced_gauge(raw_state, scales)
+
+    wrapped = gauge_balance_component_optimizer(inner)
+    updates, state = wrapped.update(grads, wrapped.init(params), params)
+    actual = optax.apply_updates(params, updates)
+    assert all(
+        bool(jnp.allclose(a, b))
+        for a, b in zip(jax.tree.leaves(actual), jax.tree.leaves(expected), strict=True)
+    )
+    assert all(
+        bool(jnp.allclose(a, b))
+        for a, b in zip(
+            jax.tree.leaves(state.inner_state), jax.tree.leaves(expected_state), strict=True
+        )
+    )
+    V, U = actual.site("site")
+    assert jnp.allclose(jnp.linalg.norm(V, axis=0), jnp.linalg.norm(U, axis=1))
+
+
+def test_balanced_c_covariant_update_scaling():
+    updates = component_stacks_from_sites({"site": (jnp.ones((12, 48)), jnp.ones((48, 7)))})
+    transform = scale_component_updates_c_covariant_balanced()
+    scaled, _ = transform.update(updates, transform.init(updates))
+    V, U = scaled.site("site")
+    expected = (12 / 48) ** 0.75
+    assert jnp.all(expected == V)
+    assert jnp.all(expected == U)
 
 
 def test_optimizer_config_type_discriminator():

--- a/param_decomp/core/tests/test_optim_torch_parity.py
+++ b/param_decomp/core/tests/test_optim_torch_parity.py
@@ -14,11 +14,13 @@ from jax.typing import ArrayLike
 from jaxtyping import Array
 from pydantic import TypeAdapter
 
+from param_decomp.core.components import component_stacks_from_sites
 from param_decomp.core.configs import AdamWOptimizerConfig, AnyOptimizerConfig, MuonOptimizerConfig
 from param_decomp.core.run_state import (
     _optimizer_with_clip,
     clip_by_global_norm_with_eps,
     optax_schedule,
+    scale_component_updates_c_covariant,
     stacked_muon_dimension_numbers,
 )
 from param_decomp.core.schedule import Knot, ScheduleConfig
@@ -112,6 +114,25 @@ def test_grad_clip_noop_below_threshold():
     out = _clip(clip, grads)
     assert float(out["a"][0]) == pytest.approx(3.0)
     assert float(out["a"][1]) == pytest.approx(4.0)
+
+
+def test_c_covariant_component_scaling_is_post_optimizer_and_shape_aware():
+    updates = component_stacks_from_sites(
+        {
+            "wide": (jnp.ones((40, 200)), jnp.ones((200, 10))),
+            "tall": (jnp.ones((10, 40)), jnp.ones((40, 40))),
+        }
+    )
+    transform = scale_component_updates_c_covariant()
+    scaled, _ = transform.update(updates, transform.init(updates))
+
+    wide_v, wide_u = scaled.site("wide")
+    assert jnp.allclose(wide_v, (40 / 200) ** 0.5)
+    assert jnp.allclose(wide_u, 40 / 200)
+
+    tall_v, tall_u = scaled.site("tall")
+    assert jnp.allclose(tall_v, (10 / 40) ** 0.5)
+    assert jnp.allclose(tall_u, 10 / 40)
 
 
 def test_muon_orthogonalizes_2d_leaves_and_adam_falls_back_elsewhere():

--- a/param_decomp/core/tests/test_optim_torch_parity.py
+++ b/param_decomp/core/tests/test_optim_torch_parity.py
@@ -6,6 +6,8 @@
   optax's eps-free `clip_by_global_norm`.
 """
 
+from typing import Any, cast
+
 import jax
 import jax.numpy as jnp
 import optax
@@ -128,13 +130,13 @@ def test_c_covariant_component_scaling_is_post_optimizer_and_shape_aware():
         }
     )
     transform = scale_component_updates_c_covariant()
-    scaled, _ = transform.update(updates, transform.init(updates))
+    scaled, _ = transform.update(cast(Any, updates), transform.init(cast(Any, updates)))
 
-    wide_v, wide_u = scaled.site("wide")
+    wide_v, wide_u = cast(Any, scaled).site("wide")
     assert jnp.allclose(wide_v, (40 / 200) ** 0.5)
     assert jnp.allclose(wide_u, 40 / 200)
 
-    tall_v, tall_u = scaled.site("tall")
+    tall_v, tall_u = cast(Any, scaled).site("tall")
     assert jnp.allclose(tall_v, (10 / 40) ** 0.5)
     assert jnp.allclose(tall_u, 10 / 40)
 
@@ -255,7 +257,7 @@ def test_stacked_muon_update_matches_optax_muon():
         state = opt.init(params)
         p = params
         for _ in range(2):
-            updates, state = opt.update(grads, state, p)
+            updates, state = opt.update(cast(Any, grads), state, cast(Any, p))
             p = jax.tree.map(lambda x, u: x + u, p, updates)
         return p
 
@@ -352,11 +354,11 @@ def test_stacked_muon_bf16_ns_is_sane():
         state = opt.init(params)
         p = params
         for _ in range(2):
-            raw, state = opt.update(grads, state, p)
+            raw, state = opt.update(cast(Any, grads), state, cast(Any, p))
             p = jax.tree.map(
                 lambda x, u: x + u, p, jax.tree.unflatten(treedef, jax.tree.leaves(raw))
             )
-        raw, state = opt.update(grads, state, p)
+        raw, state = opt.update(cast(Any, grads), state, cast(Any, p))
         return jax.tree.unflatten(treedef, jax.tree.leaves(raw)), state
 
     bf16_updates, bf16_state = run("bfloat16")
@@ -426,7 +428,7 @@ def test_component_gauge_balance_preserves_each_rank_one_term():
     components = component_stacks_from_sites({"site": (V[0], U[0])})
 
     balanced, _ = balance_component_stacks(components)
-    Vb, Ub = balanced.site("site")
+    Vb, Ub = cast(Any, balanced).site("site")
 
     original_terms = jnp.einsum("ic,co->cio", V[0], U[0])
     balanced_terms = jnp.einsum("ic,co->cio", Vb, Ub)
@@ -451,14 +453,14 @@ def test_gauge_balanced_adam_retracts_update_and_transforms_moments():
     grads = jax.tree.map(lambda x: jnp.arange(x.size, dtype=x.dtype).reshape(x.shape) + 1, params)
     inner = optax.adamw(1e-2, weight_decay=0.0)
 
-    raw_updates, raw_state = inner.update(grads, inner.init(params), params)
-    raw_proposed = optax.apply_updates(params, raw_updates)
-    expected, scales = balance_component_stacks(raw_proposed)
+    raw_updates, raw_state = inner.update(grads, inner.init(cast(Any, params)), cast(Any, params))
+    raw_proposed = optax.apply_updates(cast(Any, params), raw_updates)
+    expected, scales = balance_component_stacks(cast(Any, raw_proposed))
     expected_state = _transform_adam_moments_to_balanced_gauge(raw_state, scales)
 
     wrapped = gauge_balance_component_optimizer(inner)
-    updates, state = wrapped.update(grads, wrapped.init(params), params)
-    actual = optax.apply_updates(params, updates)
+    updates, state = wrapped.update(grads, wrapped.init(cast(Any, params)), cast(Any, params))
+    actual = cast(Any, optax.apply_updates(cast(Any, params), updates))
     assert all(
         bool(jnp.allclose(a, b))
         for a, b in zip(jax.tree.leaves(actual), jax.tree.leaves(expected), strict=True)
@@ -466,7 +468,9 @@ def test_gauge_balanced_adam_retracts_update_and_transforms_moments():
     assert all(
         bool(jnp.allclose(a, b))
         for a, b in zip(
-            jax.tree.leaves(state.inner_state), jax.tree.leaves(expected_state), strict=True
+            jax.tree.leaves(cast(Any, state).inner_state),
+            jax.tree.leaves(expected_state),
+            strict=True,
         )
     )
     V, U = actual.site("site")
@@ -476,8 +480,8 @@ def test_gauge_balanced_adam_retracts_update_and_transforms_moments():
 def test_balanced_c_covariant_update_scaling():
     updates = component_stacks_from_sites({"site": (jnp.ones((12, 48)), jnp.ones((48, 7)))})
     transform = scale_component_updates_c_covariant_balanced()
-    scaled, _ = transform.update(updates, transform.init(updates))
-    V, U = scaled.site("site")
+    scaled, _ = transform.update(cast(Any, updates), transform.init(cast(Any, updates)))
+    V, U = cast(Any, scaled).site("site")
     expected = (12 / 48) ** 0.75
     assert jnp.all(expected == V)
     assert jnp.all(expected == U)

--- a/param_decomp/core/tests/test_slot_surgery.py
+++ b/param_decomp/core/tests/test_slot_surgery.py
@@ -1,6 +1,8 @@
 """Slot surgery primitives (#820): function preservation at birth, GradMax first-gradient
 alignment, edit locality, bitwise rollback, fail-closed arms."""
 
+from typing import Any, cast
+
 import jax
 import jax.numpy as jnp
 import optax
@@ -27,15 +29,14 @@ def make_state(key: jax.Array) -> TrainState:
     vu = {}
     for i, spec in enumerate(SITES):
         V = jax.random.normal(jax.random.fold_in(k1, i), (spec.d_in, spec.C))
-        U = jax.random.normal(jax.random.fold_in(k2, i), (spec.C, spec.d_out))
-        U = U.at[4:, :].set(0.0)  # slots 4,5 exact null
-        vu[spec.name] = (V, U)
+        U_full = jax.random.normal(jax.random.fold_in(k2, i), (spec.C, spec.d_out))
+        vu[spec.name] = (V, U_full.at[4:, :].set(0.0))  # slots 4,5 exact null
     components = component_stacks_from_sites(vu)
     ci_fn = build_ci_fn(LayerwiseMLPCIArch(hidden_dims=(16,), has_position_axis=False), SITES, k3)
     opt = optax.chain(optax.clip_by_global_norm(1.0), optax.adamw(1e-3, weight_decay=0.0))
     import equinox as eqx
 
-    vu_opt = opt.init(components)
+    vu_opt = opt.init(cast(Any, components))  # ComponentStacks is a pytree
     ci_opt = opt.init(eqx.filter(ci_fn, eqx.is_inexact_array))
     return TrainState(
         decomposition=Decomposition(components=components, ci_fn=ci_fn),
@@ -78,7 +79,7 @@ def test_first_gradient_aligns_with_leading_singular_mode() -> None:
     state = make_state(jax.random.key(3))
     target = jax.random.normal(jax.random.key(4), (8, 4))
 
-    def loss_from_components(components) -> jax.Array:
+    def loss_from_components(components: Any) -> jax.Array:
         V, U = components.site("s1")
         return 0.5 * jnp.sum((V @ U - target) ** 2)
 
@@ -108,11 +109,11 @@ def test_only_selected_slot_and_moments_change() -> None:
     assert jnp.array_equal(V0[:, keep], V1[:, keep])
     assert jnp.array_equal(U0[keep, :], U1[keep, :])
     # CI head: only column 4 and bias 4 of s1 moved
-    w0 = state.decomposition.ci_fn.site_mlps["s1"].weights[-1]
-    w1 = born.decomposition.ci_fn.site_mlps["s1"].weights[-1]
+    w0 = cast(Any, state.decomposition.ci_fn).site_mlps["s1"].weights[-1]
+    w1 = cast(Any, born.decomposition.ci_fn).site_mlps["s1"].weights[-1]
     assert jnp.array_equal(w0[:, keep], w1[:, keep])
     assert jnp.all(w1[:, 4] == 0.0)
-    assert born.decomposition.ci_fn.site_mlps["s1"].biases[-1][4] == 1.0
+    assert cast(Any, born.decomposition.ci_fn).site_mlps["s1"].biases[-1][4] == 1.0
 
 
 def test_rollback_restores_the_entire_pretrial_frontier() -> None:
@@ -128,9 +129,9 @@ def test_rollback_restores_the_entire_pretrial_frontier() -> None:
         # unrelated-slot edit via the public path (slot 5 is also null)
         born, "s1", 5, jax.random.normal(jax.random.key(9), (8,))
     )
-    hidden_w = contaminated.decomposition.ci_fn.site_mlps["s2"].weights[0]
+    hidden_w = cast(Any, contaminated.decomposition.ci_fn).site_mlps["s2"].weights[0]
     contaminated = eqx.tree_at(
-        lambda s: s.decomposition.ci_fn.site_mlps["s2"].weights[0],
+        lambda s: cast(Any, s.decomposition.ci_fn).site_mlps["s2"].weights[0],
         contaminated, hidden_w + 1.0,
     )  # fmt: skip
     contaminated = eqx.tree_at(
@@ -185,7 +186,7 @@ def test_truncate_active_prefix_nulls_tail_and_is_idempotent() -> None:
     # represented matrix is the prefix-only product (allclose: XLA reduction order
     # differs between a 6-wide matmul with zero rows and a 2-wide matmul)
     assert jnp.allclose(represented(truncated, "s1"), V[:, :2] @ U[:2, :], atol=1e-6)
-    b = truncated.decomposition.ci_fn.site_mlps["s1"].biases[-1]
+    b = cast(Any, truncated.decomposition.ci_fn).site_mlps["s1"].biases[-1]
     assert jnp.all(b[2:] == 0.0)
     again = truncate_active_prefix(truncated, {"s1": 2})
     for a, c in zip(

--- a/param_decomp/core/tests/test_slot_surgery.py
+++ b/param_decomp/core/tests/test_slot_surgery.py
@@ -127,7 +127,10 @@ def test_rollback_restores_the_entire_pretrial_frontier() -> None:
     # layer, both optimizer states, and the step counter
     contaminated = birth_slot(
         # unrelated-slot edit via the public path (slot 5 is also null)
-        born, "s1", 5, jax.random.normal(jax.random.key(9), (8,))
+        born,
+        "s1",
+        5,
+        jax.random.normal(jax.random.key(9), (8,)),
     )
     hidden_w = cast(Any, contaminated.decomposition.ci_fn).site_mlps["s2"].weights[0]
     contaminated = eqx.tree_at(
@@ -191,7 +194,9 @@ def test_truncate_active_prefix_nulls_tail_and_is_idempotent() -> None:
     again = truncate_active_prefix(truncated, {"s1": 2})
     for a, c in zip(
         jax.tree_util.tree_leaves((again.decomposition, again.training.components_opt_state)),
-        jax.tree_util.tree_leaves((truncated.decomposition, truncated.training.components_opt_state)),
+        jax.tree_util.tree_leaves(
+            (truncated.decomposition, truncated.training.components_opt_state)
+        ),
         strict=True,
     ):
         if hasattr(a, "shape"):

--- a/param_decomp/core/tests/test_slot_surgery.py
+++ b/param_decomp/core/tests/test_slot_surgery.py
@@ -208,9 +208,50 @@ def test_snapshot_owns_independent_buffers() -> None:
     # invalidated by the next step, so every array leaf must be an independent copy
     state = make_state(jax.random.key(30))
     snap = snapshot_trial(state, "s1", 4)
-    src_leaves = [x for x in jax.tree_util.tree_leaves(state) if hasattr(x, "unsafe_buffer_pointer")]
-    snap_leaves = [x for x in jax.tree_util.tree_leaves(snap.state) if hasattr(x, "unsafe_buffer_pointer")]
+    src_leaves = [
+        x for x in jax.tree_util.tree_leaves(state) if hasattr(x, "unsafe_buffer_pointer")
+    ]
+    snap_leaves = [
+        x for x in jax.tree_util.tree_leaves(snap.state) if hasattr(x, "unsafe_buffer_pointer")
+    ]
     assert len(src_leaves) == len(snap_leaves) and src_leaves
     for a, b in zip(src_leaves, snap_leaves, strict=True):
         assert a.unsafe_buffer_pointer() != b.unsafe_buffer_pointer()
         assert jnp.array_equal(a, b)
+
+
+def test_batched_birth_is_function_preserving_and_per_slot_gradients_match_modes() -> None:
+    from param_decomp.core.slot_surgery import birth_directions_from_grad, birth_slots
+
+    state = make_state(jax.random.key(40))
+    target = jax.random.normal(jax.random.key(41), (8, 4))
+    before = represented(state, "s1")
+    G = jax.grad(lambda M: 0.5 * jnp.sum((M - target) ** 2))(before)
+    P, sigmas = birth_directions_from_grad(G, 2)
+    assert jnp.allclose(P.T @ P, jnp.eye(2), atol=1e-5)
+    assert bool(sigmas[0] >= sigmas[1])
+
+    born = birth_slots(state, "s1", (4, 5), P)
+    assert jnp.array_equal(represented(born, "s1"), before)  # exact, whole batch
+
+    def loss_from_components(components: Any) -> jax.Array:
+        V, U = components.site("s1")
+        return 0.5 * jnp.sum((V @ U - target) ** 2)
+
+    _, gU = jax.grad(loss_from_components)(born.decomposition.components).site("s1")
+    for i, slot in enumerate((4, 5)):
+        assert jnp.allclose(jnp.linalg.norm(gU[slot, :]), sigmas[i], rtol=1e-4)
+
+
+def test_batched_birth_refuses_non_orthonormal_and_duplicate_slots() -> None:
+    from param_decomp.core.slot_surgery import birth_slots
+
+    state = make_state(jax.random.key(42))
+    v = jax.random.normal(jax.random.key(43), (8,))
+    v = v / jnp.linalg.norm(v)
+    doubled = jnp.stack([v, v], axis=1)  # rank-1 "batch"
+    with pytest.raises(AssertionError):
+        birth_slots(state, "s1", (4, 5), doubled)
+    ortho = jnp.linalg.qr(jax.random.normal(jax.random.key(44), (8, 2)))[0]
+    with pytest.raises(AssertionError):
+        birth_slots(state, "s1", (4, 4), ortho)

--- a/param_decomp/core/tests/test_slot_surgery.py
+++ b/param_decomp/core/tests/test_slot_surgery.py
@@ -115,23 +115,42 @@ def test_only_selected_slot_and_moments_change() -> None:
     assert born.decomposition.ci_fn.site_mlps["s1"].biases[-1][4] == 1.0
 
 
-def test_rollback_is_bitwise_exact() -> None:
+def test_rollback_restores_the_entire_pretrial_frontier() -> None:
+    import equinox as eqx
+
     state = make_state(jax.random.key(7))
     snap = snapshot_trial(state, "s1", 4)
     born = birth_slot(state, "s1", 4, jax.random.normal(jax.random.key(8), (8,)))
-    # simulate the trial training the slot: perturb its slices everywhere
-    poked = birth_slot(born, "s1", 4, jax.random.normal(jax.random.key(9), (8,)))
-    restored = rollback_trial(poked, snap)
-    for getter in (
-        lambda s: s.decomposition.components.site("s1")[0],
-        lambda s: s.decomposition.components.site("s1")[1],
-        lambda s: s.decomposition.ci_fn.site_mlps["s1"].weights[-1],
-        lambda s: s.decomposition.ci_fn.site_mlps["s1"].biases[-1],
+
+    # contaminate EVERYTHING an ongoing probe trains: an unrelated slot, a CI hidden
+    # layer, both optimizer states, and the step counter
+    contaminated = birth_slot(
+        # unrelated-slot edit via the public path (slot 5 is also null)
+        born, "s1", 5, jax.random.normal(jax.random.key(9), (8,))
+    )
+    hidden_w = contaminated.decomposition.ci_fn.site_mlps["s2"].weights[0]
+    contaminated = eqx.tree_at(
+        lambda s: s.decomposition.ci_fn.site_mlps["s2"].weights[0],
+        contaminated, hidden_w + 1.0,
+    )  # fmt: skip
+    contaminated = eqx.tree_at(
+        lambda s: s.training.step, contaminated, contaminated.training.step + 7
+    )
+    bumped_opts = jax.tree_util.tree_map(
+        lambda leaf: leaf + 1 if hasattr(leaf, "dtype") else leaf,
+        (contaminated.training.components_opt_state, contaminated.training.ci_fn_opt_state),
+    )
+    contaminated = eqx.tree_at(
+        lambda s: (s.training.components_opt_state, s.training.ci_fn_opt_state),
+        contaminated, bumped_opts,
+    )  # fmt: skip
+
+    restored = rollback_trial(snap)
+    for a, b in zip(
+        jax.tree_util.tree_leaves(eqx.filter(restored, eqx.is_array)),
+        jax.tree_util.tree_leaves(eqx.filter(state, eqx.is_array)),
+        strict=True,
     ):
-        assert jnp.array_equal(getter(restored), getter(state))
-    flat0 = jax.tree_util.tree_leaves(state.training.components_opt_state)
-    flat1 = jax.tree_util.tree_leaves(restored.training.components_opt_state)
-    for a, b in zip(flat0, flat1, strict=True):
         assert jnp.array_equal(a, b)
 
 

--- a/param_decomp/core/tests/test_slot_surgery.py
+++ b/param_decomp/core/tests/test_slot_surgery.py
@@ -1,0 +1,152 @@
+"""Slot surgery primitives (#820): function preservation at birth, GradMax first-gradient
+alignment, edit locality, bitwise rollback, fail-closed arms."""
+
+import jax
+import jax.numpy as jnp
+import optax
+import pytest
+
+from param_decomp.core.ci_fn import LayerwiseMLPCIArch, build_ci_fn
+from param_decomp.core.components import SiteSpec, component_stacks_from_sites
+from param_decomp.core.slot_surgery import (
+    birth_direction_from_grad,
+    birth_slot,
+    find_inactive_slot,
+    protected_mask,
+    rollback_trial,
+    select_birth_site,
+    snapshot_trial,
+)
+from param_decomp.core.train import Decomposition, TrainingItem, TrainState
+
+SITES = (SiteSpec("s1", d_in=8, d_out=4, C=6), SiteSpec("s2", d_in=8, d_out=4, C=6))
+
+
+def make_state(key: jax.Array) -> TrainState:
+    k1, k2, k3 = jax.random.split(key, 3)
+    vu = {}
+    for i, spec in enumerate(SITES):
+        V = jax.random.normal(jax.random.fold_in(k1, i), (spec.d_in, spec.C))
+        U = jax.random.normal(jax.random.fold_in(k2, i), (spec.C, spec.d_out))
+        U = U.at[4:, :].set(0.0)  # slots 4,5 exact null
+        vu[spec.name] = (V, U)
+    components = component_stacks_from_sites(vu)
+    ci_fn = build_ci_fn(LayerwiseMLPCIArch(hidden_dims=(16,), has_position_axis=False), SITES, k3)
+    opt = optax.chain(optax.clip_by_global_norm(1.0), optax.adamw(1e-3, weight_decay=0.0))
+    import equinox as eqx
+
+    vu_opt = opt.init(components)
+    ci_opt = opt.init(eqx.filter(ci_fn, eqx.is_inexact_array))
+    return TrainState(
+        decomposition=Decomposition(components=components, ci_fn=ci_fn),
+        training=TrainingItem(
+            components_opt_state=vu_opt,
+            ci_fn_opt_state=ci_opt,
+            adversaries={},
+            step=jnp.zeros((), jnp.int32),
+        ),  # fmt: skip
+    )
+
+
+def represented(state: TrainState, site: str) -> jax.Array:
+    V, U = state.decomposition.components.site(site)
+    return V @ U
+
+
+def test_find_inactive_slot_and_exhaustion() -> None:
+    state = make_state(jax.random.key(0))
+    assert find_inactive_slot(state.decomposition.components, "s1") == 4
+    V, U = state.decomposition.components.site("s1")
+    full = component_stacks_from_sites(
+        {"s1": (V, jnp.ones_like(U)), "s2": state.decomposition.components.site("s2")}
+    )
+    assert find_inactive_slot(full, "s1") is None
+
+
+def test_birth_preserves_represented_matrix_exactly() -> None:
+    state = make_state(jax.random.key(1))
+    before = represented(state, "s1")
+    direction = jax.random.normal(jax.random.key(2), (8,))
+    born = birth_slot(state, "s1", 4, direction)
+    assert jnp.array_equal(represented(born, "s1"), before)
+    V, U = born.decomposition.components.site("s1")
+    assert jnp.allclose(jnp.linalg.norm(V[:, 4]), 1.0, atol=1e-6)
+    assert jnp.all(U[4, :] == 0.0)
+
+
+def test_first_gradient_aligns_with_leading_singular_mode() -> None:
+    state = make_state(jax.random.key(3))
+    target = jax.random.normal(jax.random.key(4), (8, 4))
+
+    def loss_from_components(components) -> jax.Array:
+        V, U = components.site("s1")
+        return 0.5 * jnp.sum((V @ U - target) ** 2)
+
+    G = jax.grad(lambda M: 0.5 * jnp.sum((M - target) ** 2))(represented(state, "s1"))
+    p, sigma = birth_direction_from_grad(G)
+    born = birth_slot(state, "s1", 4, p)
+    grads = jax.grad(loss_from_components)(born.decomposition.components)
+    _, gU = grads.site("s1")
+    # dL/dU[slot] = p^T G = sigma q^T: check norm and alignment with the exact SVD
+    assert jnp.allclose(jnp.linalg.norm(gU[4, :]), sigma, rtol=1e-4)
+    _, s_exact, Bt = jnp.linalg.svd(G, full_matrices=False)
+    cos = jnp.abs(gU[4, :] @ Bt[0]) / (jnp.linalg.norm(gU[4, :]) + 1e-30)
+    assert cos > 0.999
+    assert jnp.allclose(sigma, s_exact[0], rtol=1e-4)
+
+
+def test_only_selected_slot_and_moments_change() -> None:
+    state = make_state(jax.random.key(5))
+    born = birth_slot(state, "s1", 4, jax.random.normal(jax.random.key(6), (8,)))
+    # untouched site identical everywhere
+    assert jnp.array_equal(
+        state.decomposition.components.site("s2")[0], born.decomposition.components.site("s2")[0]
+    )
+    V0, U0 = state.decomposition.components.site("s1")
+    V1, U1 = born.decomposition.components.site("s1")
+    keep = jnp.arange(6) != 4
+    assert jnp.array_equal(V0[:, keep], V1[:, keep])
+    assert jnp.array_equal(U0[keep, :], U1[keep, :])
+    # CI head: only column 4 and bias 4 of s1 moved
+    w0 = state.decomposition.ci_fn.site_mlps["s1"].weights[-1]
+    w1 = born.decomposition.ci_fn.site_mlps["s1"].weights[-1]
+    assert jnp.array_equal(w0[:, keep], w1[:, keep])
+    assert jnp.all(w1[:, 4] == 0.0)
+    assert born.decomposition.ci_fn.site_mlps["s1"].biases[-1][4] == 1.0
+
+
+def test_rollback_is_bitwise_exact() -> None:
+    state = make_state(jax.random.key(7))
+    snap = snapshot_trial(state, "s1", 4)
+    born = birth_slot(state, "s1", 4, jax.random.normal(jax.random.key(8), (8,)))
+    # simulate the trial training the slot: perturb its slices everywhere
+    poked = birth_slot(born, "s1", 4, jax.random.normal(jax.random.key(9), (8,)))
+    restored = rollback_trial(poked, snap)
+    for getter in (
+        lambda s: s.decomposition.components.site("s1")[0],
+        lambda s: s.decomposition.components.site("s1")[1],
+        lambda s: s.decomposition.ci_fn.site_mlps["s1"].weights[-1],
+        lambda s: s.decomposition.ci_fn.site_mlps["s1"].biases[-1],
+    ):
+        assert jnp.array_equal(getter(restored), getter(state))
+    flat0 = jax.tree_util.tree_leaves(state.training.components_opt_state)
+    flat1 = jax.tree_util.tree_leaves(restored.training.components_opt_state)
+    for a, b in zip(flat0, flat1, strict=True):
+        assert jnp.array_equal(a, b)
+
+
+def test_birth_refuses_non_null_slot_and_select_site_prefers_larger_signal() -> None:
+    state = make_state(jax.random.key(10))
+    with pytest.raises(AssertionError):
+        birth_slot(state, "s1", 0, jnp.ones((8,)))  # slot 0 is live
+    weak = jax.random.normal(jax.random.key(11), (8, 4)) * 0.01
+    strong = jax.random.normal(jax.random.key(12), (8, 4))
+    site, p, sigma = select_birth_site({"s1": weak, "s2": strong})
+    assert site == "s2" and p.shape == (8,) and float(sigma) > 0
+
+
+def test_protected_mask_shape() -> None:
+    state = make_state(jax.random.key(13))
+    mask = protected_mask(state.decomposition.components, "s1", 4)
+    assert set(mask) == {"s1"} and mask["s1"].shape == (6,) and bool(mask["s1"][4])
+    assert int(mask["s1"].sum()) == 1

--- a/param_decomp/core/tests/test_slot_surgery.py
+++ b/param_decomp/core/tests/test_slot_surgery.py
@@ -150,3 +150,29 @@ def test_protected_mask_shape() -> None:
     mask = protected_mask(state.decomposition.components, "s1", 4)
     assert set(mask) == {"s1"} and mask["s1"].shape == (6,) and bool(mask["s1"][4])
     assert int(mask["s1"].sum()) == 1
+
+
+def test_truncate_active_prefix_nulls_tail_and_is_idempotent() -> None:
+    from param_decomp.core.slot_surgery import truncate_active_prefix
+
+    state = make_state(jax.random.key(20))
+    V, U = state.decomposition.components.site("s1")
+    truncated = truncate_active_prefix(state, {"s1": 2})
+    Vt, Ut = truncated.decomposition.components.site("s1")
+    assert jnp.array_equal(Ut[:2, :], U[:2, :])  # prefix untouched
+    assert jnp.all(Ut[2:, :] == 0.0)
+    assert jnp.array_equal(Vt, V)  # V columns preserved
+    assert find_inactive_slot(truncated.decomposition.components, "s1") == 2
+    # represented matrix is the prefix-only product (allclose: XLA reduction order
+    # differs between a 6-wide matmul with zero rows and a 2-wide matmul)
+    assert jnp.allclose(represented(truncated, "s1"), V[:, :2] @ U[:2, :], atol=1e-6)
+    b = truncated.decomposition.ci_fn.site_mlps["s1"].biases[-1]
+    assert jnp.all(b[2:] == 0.0)
+    again = truncate_active_prefix(truncated, {"s1": 2})
+    for a, c in zip(
+        jax.tree_util.tree_leaves((again.decomposition, again.training.components_opt_state)),
+        jax.tree_util.tree_leaves((truncated.decomposition, truncated.training.components_opt_state)),
+        strict=True,
+    ):
+        if hasattr(a, "shape"):
+            assert jnp.array_equal(a, c)

--- a/param_decomp/core/tests/test_slot_surgery.py
+++ b/param_decomp/core/tests/test_slot_surgery.py
@@ -201,3 +201,16 @@ def test_truncate_active_prefix_nulls_tail_and_is_idempotent() -> None:
     ):
         if hasattr(a, "shape"):
             assert jnp.array_equal(a, c)
+
+
+def test_snapshot_owns_independent_buffers() -> None:
+    # the train step donates its state buffers; a snapshot holding references would be
+    # invalidated by the next step, so every array leaf must be an independent copy
+    state = make_state(jax.random.key(30))
+    snap = snapshot_trial(state, "s1", 4)
+    src_leaves = [x for x in jax.tree_util.tree_leaves(state) if hasattr(x, "unsafe_buffer_pointer")]
+    snap_leaves = [x for x in jax.tree_util.tree_leaves(snap.state) if hasattr(x, "unsafe_buffer_pointer")]
+    assert len(src_leaves) == len(snap_leaves) and src_leaves
+    for a, b in zip(src_leaves, snap_leaves, strict=True):
+        assert a.unsafe_buffer_pointer() != b.unsafe_buffer_pointer()
+        assert jnp.array_equal(a, b)

--- a/param_decomp/core/tests/test_step_controls.py
+++ b/param_decomp/core/tests/test_step_controls.py
@@ -14,9 +14,10 @@ def test_protect_ci_pins_values_and_zeroes_gradient() -> None:
     def summed_lower(raw: dict[str, jax.Array]) -> jax.Array:
         ci = protect_ci(CI.from_logits(raw), protected)
         assert ci.lower["s1"][0, 0] == 1.0 and ci.upper["s1"][0, 0] == 1.0
-        return sum(v.sum() for v in ci.lower.values()) + sum(
-            v.sum() for v in ci.upper.values()
-        )
+        total = jnp.zeros(())
+        for v in list(ci.lower.values()) + list(ci.upper.values()):
+            total = total + v.sum()
+        return total
 
     grads = jax.grad(summed_lower)(logits)
     assert grads["s1"][0, 0] == 0.0  # protected: where() cuts the path to the logit

--- a/param_decomp/core/tests/test_step_controls.py
+++ b/param_decomp/core/tests/test_step_controls.py
@@ -1,0 +1,29 @@
+"""StepControls threading: protect_ci pins protected slots to 1 in both squashings and
+zeroes their gradient into the CI logits; unprotected slots are untouched."""
+
+import jax
+import jax.numpy as jnp
+
+from param_decomp.core.ci_fn import CI, protect_ci
+
+
+def test_protect_ci_pins_values_and_zeroes_gradient() -> None:
+    logits = {"s1": jnp.array([[-2.0, 0.5, 3.0]]), "s2": jnp.array([[0.25, 0.75]])}
+    protected = {"s1": jnp.array([True, False, False])}
+
+    def summed_lower(raw: dict[str, jax.Array]) -> jax.Array:
+        ci = protect_ci(CI.from_logits(raw), protected)
+        assert ci.lower["s1"][0, 0] == 1.0 and ci.upper["s1"][0, 0] == 1.0
+        return sum(v.sum() for v in ci.lower.values()) + sum(
+            v.sum() for v in ci.upper.values()
+        )
+
+    grads = jax.grad(summed_lower)(logits)
+    assert grads["s1"][0, 0] == 0.0  # protected: where() cuts the path to the logit
+    assert grads["s1"][0, 1] != 0.0  # unprotected slot in a protected site still trains
+    assert jnp.all(grads["s2"] != 0.0)  # unlisted site untouched
+
+
+def test_protect_ci_none_is_identity() -> None:
+    ci = CI.from_logits({"s1": jnp.array([[0.5]])})
+    assert protect_ci(ci, None) is ci

--- a/param_decomp/core/tests/test_svd_null_tail_init.py
+++ b/param_decomp/core/tests/test_svd_null_tail_init.py
@@ -1,0 +1,58 @@
+"""svd_null_tail init (PDConfig.component_init): exact SVD start, exact null tail,
+prefix-stable across C, CI head pinned 1/0 by slot."""
+
+import jax
+import jax.numpy as jnp
+
+from param_decomp.core.ci_fn import (
+    LayerwiseMLPCIArch,
+    build_ci_fn,
+    pin_ci_head_null_tail,
+)
+from param_decomp.core.components import (
+    ComponentStacks,
+    SiteSpec,
+    init_stack_arrays_svd_null_tail,
+    site_slots_for,
+)
+
+SITES = (SiteSpec("linear1", d_in=40, d_out=10, C=100),)
+
+
+def _weights(key: jax.Array) -> dict[str, jax.Array]:
+    return {"linear1": jax.random.normal(key, (10, 40))}
+
+
+def _stacks(sites: tuple[SiteSpec, ...], weights: dict[str, jax.Array]) -> ComponentStacks:
+    return ComponentStacks(
+        stacks=init_stack_arrays_svd_null_tail(sites, weights, jax.random.key(1)),
+        site_slots=site_slots_for(sites),
+    )
+
+
+def test_svd_slots_reproduce_the_weight_and_tail_is_null() -> None:
+    weights = _weights(jax.random.key(0))
+    V, U = _stacks(SITES, weights).site("linear1")
+    assert V.shape == (40, 100) and U.shape == (100, 10)
+    r = 10
+    assert jnp.allclose(V[:, :r] @ U[:r, :], weights["linear1"].T, atol=1e-4)
+    assert jnp.allclose(V @ U, weights["linear1"].T, atol=1e-4)  # tail adds nothing
+    assert jnp.all(U[r:, :] == 0.0)
+    assert jnp.all(jnp.linalg.norm(V[:, r:], axis=0) > 0.0)  # tail V columns are live draws
+
+
+def test_tail_v_columns_are_prefix_stable_across_c() -> None:
+    weights = _weights(jax.random.key(0))
+    small = _stacks((SiteSpec("linear1", 40, 10, C=50),), weights).site("linear1")
+    large = _stacks((SiteSpec("linear1", 40, 10, C=100),), weights).site("linear1")
+    assert jnp.array_equal(small[0], large[0][:, :50])
+
+
+def test_ci_head_pinned_one_for_rank_slots_zero_for_tail() -> None:
+    ci_fn = build_ci_fn(
+        LayerwiseMLPCIArch(hidden_dims=(50,), has_position_axis=False), SITES, jax.random.key(2)
+    )
+    pinned = pin_ci_head_null_tail(ci_fn, SITES)
+    ci = pinned({"linear1": jax.random.normal(jax.random.key(3), (8, 40))}, remat=False)
+    assert jnp.all(ci.lower["linear1"][:, :10] == 1.0)
+    assert jnp.all(ci.lower["linear1"][:, 10:] == 0.0)

--- a/param_decomp/core/train.py
+++ b/param_decomp/core/train.py
@@ -34,7 +34,7 @@ from param_decomp.core.adversary import (
     mixed_persistent_stochastic_masks,
     source_masks,
 )
-from param_decomp.core.ci_fn import CI, CIFn
+from param_decomp.core.ci_fn import CI, CIFn, protect_ci
 from param_decomp.core.components import ComponentStacks
 from param_decomp.core.configs import SmoothL0ImportanceMinimalityLossConfig
 from param_decomp.core.jit_util import filter_jit
@@ -100,6 +100,23 @@ class TrainState:
 
     decomposition: Decomposition
     training: TrainingItem
+
+
+@jax.tree_util.register_dataclass
+@dataclass(frozen=True)
+class StepControls:
+    """Host-controller inputs to one train step (the recon-budget / capacity-birth control
+    laws, task #811): `complexity_scale` multiplies the COMBINED imp-min + frequency force
+    (they are one local gate pressure — scaling only one leaves the other as an unrelaxable
+    pruning force at the controller floor), `protected` holds birth-protected slots at CI
+    exactly 1 (see `ci_fn.protect_ci`). `constant()` is the no-controller identity."""
+
+    complexity_scale: Array
+    protected: dict[str, Array] | None
+
+    @staticmethod
+    def constant() -> "StepControls":
+        return StepControls(complexity_scale=jnp.ones((), jnp.float32), protected=None)
 
 
 def _grad_norm_metrics(components_grad: ComponentStacks, ci_fn_grad: Any) -> dict[str, Array]:
@@ -306,7 +323,12 @@ def make_train_step(
         state: TrainState,
         batch: Any,
         key: PRNGKeyArray,
+        controls: StepControls | None = None,
     ) -> tuple[TrainState, dict[str, Array]]:
+        # None resolves at TRACE time (static) to the no-controller identity — the default
+        # exists so the controller seam costs existing callers nothing.
+        if controls is None:
+            controls = StepControls.constant()
         decomposition = state.decomposition
         training = state.training
         step_f32 = training.step.astype(jnp.float32)
@@ -336,8 +358,13 @@ def make_train_step(
         # (≈10x-the-target) CI fn is forward-evaluated ONCE, not once detached for the ascend +
         # once inside the main backward.
         with jax.named_scope("pd_ci_fn_fwd"):
+            # protect_ci INSIDE the vjp'd fn: the `where` must sit between the CI fn and
+            # every consumer so protected slots see zero gradient, not a post-hoc value edit.
             ci, ci_vjp = eqx.filter_vjp(
-                lambda cf: ci_batch_sharded(cast_floating(cf, COMPUTE_DT)(taps, remat=remat_ci_fn)),
+                lambda cf: protect_ci(
+                    ci_batch_sharded(cast_floating(cf, COMPUTE_DT)(taps, remat=remat_ci_fn)),
+                    controls.protected,
+                ),
                 decomposition.ci_fn,
             )
         ci_lower_detached = jax.lax.stop_gradient(ci).lower
@@ -542,7 +569,9 @@ def make_train_step(
                     )  # fmt: skip
                 term_losses.append(total / len(draws))
 
-            total_loss = faith_coeff * faith_loss + imp_coeff * imp_lp + freq_coeff * imp_freq
+            total_loss = faith_coeff * faith_loss + controls.complexity_scale * (
+                imp_coeff * imp_lp + freq_coeff * imp_freq
+            )
             for term, term_loss in zip(recon_terms, term_losses, strict=True):
                 total_loss = total_loss + term.coeff * term_loss
             return total_loss, (faith_loss, imp_lp, imp_freq, tuple(term_losses))
@@ -599,6 +628,7 @@ def make_train_step(
             imp_loss_key: imp_lp,
             "freq": imp_freq,
             imp_min_param_key: imp_min_param,
+            "controls/complexity_scale": controls.complexity_scale,
             **{f"loss/{t.name}": v for t, v in zip(recon_terms, term_losses, strict=True)},
             **grad_norm_metrics,
         }


### PR DESCRIPTION
Pure lifecycle surgery primitives for the recon-budget controller's birth/probe events — no run-loop, config, or model coupling. Implements the #820 spec exactly:

- `find_inactive_slot`: exact-null U row; `None` = the controller's CAPACITY_EXHAUSTED input.
- `birth_direction_from_grad` / `select_birth_site`: GradMax leading singular pair of the per-site represented-matrix recon gradient (power iteration); the zero-plumbing null-slot probe for large targets is documented on the function.
- `birth_slot`: function-preserving (represented matrix unchanged EXACTLY — unit-p V column, exact-zero U row), CI-head column zeroed with bias 1, the slot's Adam moments reset in both optimizers.
- `snapshot_trial` / `rollback_trial`: bitwise restore through the single shared mutation path.
- `protected_mask`: the `StepControls.protected` entry for gate protection.

Fail-closed: MLP CI fns only (chunkwise raises), exactly one `ScaleByAdamState` per optimizer chain (muon raises). Tests cover the four spec requirements: VU unchanged at event, first-gradient alignment with the exact SVD, only-selected-slot/moments changed, exact rollback.

**Experiment branch stacked on `bridge/task-811-controller`** (base shown vs main includes the controller + svd-init + c-covariant commits); review scope is the tip commit 7cb4e33cd. Not an adoption PR — consumed by the #811 acceptance harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)