### PR TITLE
Support untied-head attention-sink LlamaSimpleMLP targets

### DIFF
--- a/param_decomp/experiments/lm/pretrain/CLAUDE.md
+++ b/param_decomp/experiments/lm/pretrain/CLAUDE.md
@@ -35,8 +35,9 @@ The trainer is a library subpackage under `param_decomp/pretrain/`:
 A freshly-pretrained target is decomposable with NO conversion. `pretrain.train` writes
 `<data_root>/pretrain_cache/<project>-<run_id>/model_step_<N>.safetensors` keyed
 `h.{i}.attn.{q,k,v,o}_proj.weight`, `h.{i}.mlp.{c_fc,down_proj}.weight`,
-`h.{i}.rms_{1,2}.weight`, `wte.weight`, `ln_f.weight` (NO `lm_head.weight` — tied), every
-weight `(d_out, d_in)` — exactly what `param_decomp.targets.llama_simple_mlp` reads. A
+`h.{i}.rms_{1,2}.weight`, `wte.weight`, `ln_f.weight`, and (when configured)
+`lm_head.weight` plus `h.{i}.attn.sinks`. Every matrix is `(d_out, d_in)` — exactly what
+`param_decomp.targets.llama_simple_mlp` reads. A
 decomposition config points at it via `target.spec`:
 
 ```yaml

--- a/param_decomp/pretrain/cache.py
+++ b/param_decomp/pretrain/cache.py
@@ -60,15 +60,25 @@ def torch_model_config_dict(cfg: PretrainConfig) -> dict[str, object]:
     match model.model_type:
         case "GPT2Simple":
             return base
-        case "LlamaSimple" | "LlamaSimpleMLP":
-            return base | {
-                "rotary_base": model.rotary_base,
-                "n_ctx": model.n_ctx,
-                "n_key_value_heads": model.n_key_value_heads,
-                "rms_norm_eps": model.rms_norm_eps,
-                "mlp_bias": False,
-                "attn_bias": False,
-                "use_grouped_query_attention": True,
-                "rotary_adjacent_pairs": False,
-                "rotary_dim": model.head_dim,
+        case "LlamaSimple":
+            extras = {"tie_word_embeddings": True, "attention_sinks": False}
+        case "LlamaSimpleMLP":
+            extras = {
+                "tie_word_embeddings": model.tie_word_embeddings,
+                "attention_sinks": model.attention_sinks,
             }
+    return (
+        base
+        | {
+            "rotary_base": model.rotary_base,
+            "n_ctx": model.n_ctx,
+            "n_key_value_heads": model.n_key_value_heads,
+            "rms_norm_eps": model.rms_norm_eps,
+            "mlp_bias": False,
+            "attn_bias": False,
+            "use_grouped_query_attention": True,
+            "rotary_adjacent_pairs": False,
+            "rotary_dim": model.head_dim,
+        }
+        | extras
+    )

--- a/param_decomp/pretrain/configs/pile_llama_simple_mlp-4L-768-untied-sinks.yaml
+++ b/param_decomp/pretrain/configs/pile_llama_simple_mlp-4L-768-untied-sinks.yaml
@@ -1,0 +1,37 @@
+run_name: pile_llama_simple_mlp-4L-768-untied-sinks
+seed: 45
+dp: 8
+dtype: bfloat16
+global_batch: 1024
+num_iterations: 100000
+warmup_iters: 600
+learning_rate: 3e-4
+learning_rate_decay_frac: 0.1
+weight_decay: 0.1
+grad_clip: 1.0
+log_every: 100
+val_every: 1000
+val_steps: 20
+save_every: 1000
+
+model:
+  model_type: LlamaSimpleMLP
+  tie_word_embeddings: false
+  attention_sinks: true
+  block_size: 512
+  vocab_size: 50277
+  n_layer: 4
+  n_head: 6
+  n_embd: 768
+  n_intermediate: 3072
+  rotary_base: 10000
+  n_ctx: 512
+  n_key_value_heads: 6
+  rms_norm_eps: 1.0e-06
+
+data:
+  kind: name
+  name: pile_neox_tok_512
+
+wandb:
+  project: spd

--- a/param_decomp/pretrain/models.py
+++ b/param_decomp/pretrain/models.py
@@ -7,13 +7,15 @@ capability reimplementation (next-token CE, AdamW, cosine LR) — NOT a bit-exac
 The `LlamaSimpleMLP` checkpoint format is load-bearing: `param_decomp.targets.llama_simple_mlp`
 (`load_target_from_pretrain_cache`) reads safetensors keyed
 `h.{i}.attn.{q,k,v,o}_proj.weight`, `h.{i}.mlp.{c_fc,down_proj}.weight`,
-`h.{i}.rms_{1,2}.weight`, `wte.weight`, `ln_f.weight` (NO `lm_head.weight` — tied to
-`wte`), every weight in torch `nn.Linear` orientation `(d_out, d_in)`. `state_dict`
+`h.{i}.rms_{1,2}.weight`, `wte.weight`, `ln_f.weight`, plus `lm_head.weight` for an
+untied head and `h.{i}.attn.sinks` for learned sink logits. Every matrix uses torch
+`nn.Linear` orientation `(d_out, d_in)`. `state_dict`
 (below) emits exactly those keys, so a freshly-pretrained target is decomposable with no
 conversion. The other two archs follow the same key convention for symmetry.
 
-All three are pre-norm decoder blocks under a flat `h.{i}.` module tree, `wte` tied to
-`lm_head`, no biases on the Llama variants. RoPE is plain rotate-half
+All three are pre-norm decoder blocks under a flat `h.{i}.` module tree. The original
+variants tie `wte` to `lm_head`; `LlamaSimpleMLP` can instead carry a separate output
+head and learned attention-sink logits. The Llama variants have no biases. RoPE is plain rotate-half
 (`param_decomp.vendored_jax.llama.{rope_cos_sin,apply_rope}`); the GELU is the tanh approximation
 (torch `NewGELU`), matching the JAX port pinned by `param_decomp/tests/targets/simple_mlp_equivalence/`.
 
@@ -37,6 +39,7 @@ from param_decomp.core.base_config import BaseConfig
 from param_decomp.vendored_jax.llama import (
     apply_rope,
     causal_sdpa,
+    causal_sink_sdpa,
     repeat_kv,
     rms_norm,
     rope_cos_sin,
@@ -87,6 +90,8 @@ class LlamaSimpleConfig(BaseConfig):
 
 class LlamaSimpleMLPConfig(BaseConfig):
     model_type: Literal["LlamaSimpleMLP"]
+    tie_word_embeddings: bool = True
+    attention_sinks: bool = False
     block_size: int = 1024
     vocab_size: int = 50257
     n_layer: int = 12
@@ -260,11 +265,16 @@ def init_gpt2_simple(cfg: GPT2SimpleConfig, key: Array) -> GPT2Simple:
 # ----------------------------- Llama variants (shared rotary GQA attention) -----------------------------
 
 
+class TiedLMHead(eqx.Module):
+    """No-leaf marker: logits reuse `wte` rather than carrying a second trainable array."""
+
+
 class LlamaAttention(eqx.Module):
     wq: Float[Array, "qd d"]
     wk: Float[Array, "kvd d"]
     wv: Float[Array, "kvd d"]
     wo: Float[Array, "d qd"]
+    sinks: Float[Array, " h"] | None
     n_head: int = eqx.field(static=True)
     n_kv_head: int = eqx.field(static=True)
     head_dim: int = eqx.field(static=True)
@@ -277,13 +287,12 @@ class LlamaAttention(eqx.Module):
         v = (x @ self.wv.T).reshape(b, t, self.n_kv_head, self.head_dim).transpose(0, 2, 1, 3)
         cos, sin = rope_cos_sin(inv_freq, t, x.dtype)
         q, k = apply_rope(q, k, cos, sin)
-        k = repeat_kv(k, self.n_rep)
-        v = repeat_kv(v, self.n_rep)
-        y = (
-            causal_sdpa(q, k, v, None, "auto")
-            .transpose(0, 2, 1, 3)
-            .reshape(b, t, self.n_head * self.head_dim)
+        attention = (
+            causal_sdpa(q, repeat_kv(k, self.n_rep), repeat_kv(v, self.n_rep), None, "auto")
+            if self.sinks is None
+            else causal_sink_sdpa(q, k, v, self.sinks, None)
         )
+        y = attention.transpose(0, 2, 1, 3).reshape(b, t, self.n_head * self.head_dim)
         return y @ self.wo.T
 
 
@@ -303,6 +312,11 @@ def _init_llama_attention(
         wk=_normal(keys(), (kvd, d), _linear_std(cfg, False)),
         wv=_normal(keys(), (kvd, d), _linear_std(cfg, False)),
         wo=_normal(keys(), (d, qd), _linear_std(cfg, True)),
+        sinks=(
+            _normal(keys(), (cfg.n_head,), 0.02)
+            if isinstance(cfg, LlamaSimpleMLPConfig) and cfg.attention_sinks
+            else None
+        ),
         n_head=cfg.n_head,
         n_kv_head=cfg.n_key_value_heads,
         head_dim=cfg.head_dim,
@@ -403,6 +417,7 @@ class LlamaSimpleMLPBlock(eqx.Module):
 
 class LlamaSimpleMLP(eqx.Module):
     wte: Float[Array, "vocab d"]
+    lm_head: Float[Array, "vocab d"] | TiedLMHead
     blocks: list[LlamaSimpleMLPBlock]
     norm: Float[Array, " d"]
     inv_freq: Float[Array, " hd2"]
@@ -416,11 +431,14 @@ class LlamaSimpleMLP(eqx.Module):
         for block in self.blocks:
             x = block(x, self.inv_freq)
         x = rms_norm(x, self.norm, self.eps)
-        return x @ self.wte.T
+        head = self.wte if isinstance(self.lm_head, TiedLMHead) else self.lm_head
+        return x @ head.T
 
     def state_dict(self) -> dict[str, Array]:
-        """The exact keys `param_decomp.targets.llama_simple_mlp` loads — no `lm_head` (tied)."""
+        """The exact keys `param_decomp.targets.llama_simple_mlp` loads."""
         sd: dict[str, Array] = {"wte.weight": self.wte, "ln_f.weight": self.norm}
+        if not isinstance(self.lm_head, TiedLMHead):
+            sd["lm_head.weight"] = self.lm_head
         for i, block in enumerate(self.blocks):
             sd[f"h.{i}.rms_1.weight"] = block.ln1
             sd[f"h.{i}.rms_2.weight"] = block.ln2
@@ -428,13 +446,18 @@ class LlamaSimpleMLP(eqx.Module):
             sd[f"h.{i}.attn.k_proj.weight"] = block.attn.wk
             sd[f"h.{i}.attn.v_proj.weight"] = block.attn.wv
             sd[f"h.{i}.attn.o_proj.weight"] = block.attn.wo
+            if block.attn.sinks is not None:
+                sd[f"h.{i}.attn.sinks"] = block.attn.sinks
             sd[f"h.{i}.mlp.c_fc.weight"] = block.Wfc
             sd[f"h.{i}.mlp.down_proj.weight"] = block.Wdown
         return sd
 
 
 def init_llama_simple_mlp(cfg: LlamaSimpleMLPConfig, key: Array) -> LlamaSimpleMLP:
-    keys_it = iter(jax.random.split(key, cfg.n_layer * 6 + 2))
+    keys_per_layer = 6 + int(cfg.attention_sinks)
+    keys_it = iter(
+        jax.random.split(key, cfg.n_layer * keys_per_layer + 2 + int(not cfg.tie_word_embeddings))
+    )
     nxt = lambda: next(keys_it)
     d, di = cfg.n_embd, cfg.n_intermediate
     blocks = [
@@ -448,8 +471,11 @@ def init_llama_simple_mlp(cfg: LlamaSimpleMLPConfig, key: Array) -> LlamaSimpleM
         )
         for _ in range(cfg.n_layer)
     ]
+    wte = _normal(nxt(), (cfg.vocab_size, d), 0.02)
+    lm_head = TiedLMHead() if cfg.tie_word_embeddings else _normal(nxt(), wte.shape, 0.02)
     return LlamaSimpleMLP(
-        wte=_normal(nxt(), (cfg.vocab_size, d), 0.02),
+        wte=wte,
+        lm_head=lm_head,
         blocks=blocks,
         norm=jnp.ones((d,)),
         inv_freq=_plain_rope_inv_freq(cfg),

--- a/param_decomp/targets/glu_transformer.py
+++ b/param_decomp/targets/glu_transformer.py
@@ -443,6 +443,20 @@ class FrozenAttn(eqx.Module):
         """Family hook between the head reshape and RoPE; identity for plain attention."""
         return q, k
 
+    def _sdpa(
+        self,
+        q: Float[Array, "b h t hd"],
+        k: Float[Array, "b kvh t hd"],
+        v: Float[Array, "b kvh t hd"],
+        qkv_sharding: jax.sharding.Sharding | None,
+    ) -> Array:
+        """Family hook for attention variants that change the softmax denominator."""
+        return causal_sdpa(q, k, v, qkv_sharding, self.implementation)
+
+    def _pattern_softmax(self, masked_scores: Float[Array, "b h t t"]) -> Array:
+        """Family hook matching `_sdpa` for eval-only attention maps."""
+        return jax.nn.softmax(masked_scores, axis=-1)
+
     def shardings(self, placement: PlacementRules, axes: Axes) -> "FrozenAttn":
         assert axes in (("d_out", "d_in"), ("layer", "d_out", "d_in")), axes
         column = placement.target.column.persist
@@ -502,7 +516,7 @@ class FrozenAttn(eqx.Module):
         cos, sin = rope_cos_sin(inv_freq, t, q_flat.dtype)
         q, k = apply_rope(q, k, cos, sin)
         output = (
-            causal_sdpa(q, k, v, qkv_spec, self.implementation)
+            self._sdpa(q, k, v, qkv_spec)
             .transpose(0, 2, 1, 3)
             .reshape(b, t, self.n_head * self.head_dim)
         )
@@ -532,7 +546,7 @@ class FrozenAttn(eqx.Module):
         scores = jnp.einsum("bhqd,bhkd->bhqk", q.astype(jnp.float32), k.astype(jnp.float32))
         scores = scores / self.head_dim**0.5
         causal = jnp.triu(jnp.ones((t, t), bool), k=1)
-        return jax.nn.softmax(jnp.where(causal, -jnp.inf, scores), axis=-1)
+        return self._pattern_softmax(jnp.where(causal, -jnp.inf, scores))
 
 
 class GatedMLP(eqx.Module):

--- a/param_decomp/targets/llama_simple_mlp.py
+++ b/param_decomp/targets/llama_simple_mlp.py
@@ -50,7 +50,7 @@ from param_decomp.core.components import SiteC, SiteDims, SiteSpec
 from param_decomp.core.family import ArchFamily
 from param_decomp.core.nonlinearity import NonlinearityPartition
 from param_decomp.core.placement import PlacementRules
-from param_decomp.target_ports.llama import causal_sink_sdpa
+from param_decomp.vendored_jax.llama import causal_sink_sdpa
 from param_decomp.targets.glu_transformer import (
     Anatomy,
     FrozenAttn,

--- a/param_decomp/targets/llama_simple_mlp.py
+++ b/param_decomp/targets/llama_simple_mlp.py
@@ -5,7 +5,9 @@ Torch reference (read-only, ground truth):
 pretrain run `goodfire/spd/runs/t-9d2b8f02`. Llama-style pre-RMSNorm blocks under a
 GPT2-style module tree `h.{i}.`: rotary GQA attention (`rotary_dim == head_dim`,
 plain base-`rotary_base` rotate-half RoPE — NOT llama3-rescaled) and a GELU(tanh) MLP
-`c_fc -> gelu -> down_proj`. `wte` and `lm_head` are tied; no biases anywhere.
+`c_fc -> gelu -> down_proj`. The original checkpoint ties `wte` and `lm_head`; newer
+configs may use an untied head and one learned zero-value attention-sink logit per head.
+There are no biases.
 
 The torch RoPE construction (`freq = base**(i/(rd/2))` tiled `.repeat(2)`,
 `rotate_every_two` with `rotary_adjacent_pairs=False`) is exactly the rotate-half RoPE
@@ -13,8 +15,8 @@ of `param_decomp.vendored_jax.llama.rope_cos_sin`/`apply_rope` with `inv_freq = 
 pinned by the torch-fixture equivalence test (`param_decomp/tests/targets/simple_mlp_equivalence/`).
 
 This module is the family DECLARATION: the site vocabulary (`SIMPLE_MLP_ANATOMY` binds
-`q_proj`/…/`c_fc`/`down_proj` to the engine's structural roles, `PlainMLP` + `TiedHead`
-select its anatomical arms), the torch config parser, and the checkpoint loaders. All
+`q_proj`/…/`c_fc`/`down_proj` to the engine's structural roles and `PlainMLP` selects
+its MLP arm), the torch config parser, and the checkpoint loaders. All
 forwards run on `glu_transformer.GLUDecomposedModel`.
 
 Decomposed sites are torch-module-path named: `h.{i}.attn.{q,k,v,o}_proj`,
@@ -29,19 +31,26 @@ import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, cast, get_args
+from typing import Literal, cast, get_args, override
 
+import equinox as eqx
+import jax
 import jax.numpy as jnp
 import numpy as np
 import yaml
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
 from jax.typing import DTypeLike
 from jaxtyping import Array, Float
 from safetensors import safe_open
 
 from param_decomp.core import family
+from param_decomp.core.axes import Axes
 from param_decomp.core.components import SiteC, SiteDims, SiteSpec
 from param_decomp.core.family import ArchFamily
 from param_decomp.core.nonlinearity import NonlinearityPartition
+from param_decomp.core.placement import PlacementRules
+from param_decomp.target_ports.llama import causal_sink_sdpa
 from param_decomp.targets.glu_transformer import (
     Anatomy,
     FrozenAttn,
@@ -83,6 +92,8 @@ class LlamaSimpleMLPConfig:
     rotary_base: float
     rms_norm_eps: float
     n_ctx: int
+    tie_word_embeddings: bool = True
+    attention_sinks: bool = False
 
     @property
     def head_dim(self) -> int:
@@ -102,6 +113,10 @@ def config_from_model_config_dict(raw: dict[str, object]) -> LlamaSimpleMLPConfi
     assert raw["use_grouped_query_attention"] is True, "merged-qkv (c_attn) unsupported"
     assert raw["attn_bias"] is False and raw["mlp_bias"] is False, "biases unsupported"
     assert raw["rotary_adjacent_pairs"] is False, "adjacent-pair rotary unsupported"
+    tie_word_embeddings = raw.get("tie_word_embeddings", True)
+    attention_sinks = raw.get("attention_sinks", False)
+    assert isinstance(tie_word_embeddings, bool), tie_word_embeddings
+    assert isinstance(attention_sinks, bool), attention_sinks
     cfg = LlamaSimpleMLPConfig(
         vocab_size=int(raw["vocab_size"]),  # pyright: ignore[reportArgumentType]
         n_layer=int(raw["n_layer"]),  # pyright: ignore[reportArgumentType]
@@ -112,6 +127,8 @@ def config_from_model_config_dict(raw: dict[str, object]) -> LlamaSimpleMLPConfi
         rotary_base=float(raw["rotary_base"]),  # pyright: ignore[reportArgumentType]
         rms_norm_eps=float(raw["rms_norm_eps"]),  # pyright: ignore[reportArgumentType]
         n_ctx=int(raw["n_ctx"]),  # pyright: ignore[reportArgumentType]
+        tie_word_embeddings=tie_word_embeddings,
+        attention_sinks=attention_sinks,
     )
     assert cfg.n_embd % cfg.n_head == 0 and cfg.n_head % cfg.n_kv_head == 0, cfg
     # the torch class forces rotary_dim = head_dim regardless of config; insist the
@@ -204,8 +221,7 @@ def checkpoint_safetensors_path(cache_dir: Path) -> Path:
 
 
 WeightGetter = Callable[[str], Array]
-"""Checkpoint key -> array, e.g. `h.0.attn.q_proj.weight`. `lm_head.weight` is NOT a
-key — the head is tied to `wte.weight`."""
+"""Checkpoint key -> array, e.g. `h.0.attn.q_proj.weight`."""
 
 
 def _checkpoint_weight_getter(cache_dir: Path, dtype: DTypeLike) -> WeightGetter:
@@ -218,21 +234,71 @@ def _checkpoint_weight_getter(cache_dir: Path, dtype: DTypeLike) -> WeightGetter
     return get
 
 
-def _layer_from_weights(get: WeightGetter, layer_idx: int, cfg: LlamaSimpleMLPConfig) -> GLULayer:
-    return GLULayer(
-        ln1=get(f"h.{layer_idx}.rms_1.weight"),
-        ln2=get(f"h.{layer_idx}.rms_2.weight"),
-        attn=FrozenAttn(
+class AttentionSinkFrozenAttn(FrozenAttn):
+    """Plain GQA whose softmax has one learned zero-value sink slot per query head."""
+
+    sinks: Float[Array, " h"]
+
+    @override
+    def _sdpa(
+        self,
+        q: Float[Array, "b h t hd"],
+        k: Float[Array, "b kvh t hd"],
+        v: Float[Array, "b kvh t hd"],
+        qkv_sharding: jax.sharding.Sharding | None,
+    ) -> Array:
+        return causal_sink_sdpa(q, k, v, self.sinks, qkv_sharding)
+
+    @override
+    def _pattern_softmax(self, masked_scores: Float[Array, "b h t t"]) -> Array:
+        b, h, t, _ = masked_scores.shape
+        assert self.sinks.shape == (h,), (self.sinks.shape, h)
+        sink_logits = jnp.broadcast_to(self.sinks[None, :, None, None], (b, h, t, 1))
+        return jax.nn.softmax(jnp.concatenate((masked_scores, sink_logits), axis=-1), axis=-1)[
+            ..., :-1
+        ]
+
+    @override
+    def shardings(self, placement: PlacementRules, axes: Axes) -> "AttentionSinkFrozenAttn":
+        placed = super().shardings(placement, axes)
+        assert isinstance(placed, AttentionSinkFrozenAttn)
+        expected = (*self.wq.shape[:-2], self.n_head)
+        assert self.sinks.shape == expected, (self.sinks.shape, expected)
+        return eqx.tree_at(lambda attn: attn.sinks, placed, NamedSharding(placement.mesh, P()))
+
+
+def _attn_from_weights(get: WeightGetter, layer_idx: int, cfg: LlamaSimpleMLPConfig) -> FrozenAttn:
+    if cfg.attention_sinks:
+        return AttentionSinkFrozenAttn(
             wq=get(f"h.{layer_idx}.attn.q_proj.weight"),
             wk=get(f"h.{layer_idx}.attn.k_proj.weight"),
             wv=get(f"h.{layer_idx}.attn.v_proj.weight"),
             wo=get(f"h.{layer_idx}.attn.o_proj.weight"),
+            sinks=get(f"h.{layer_idx}.attn.sinks"),
             n_head=cfg.n_head,
             n_kv_head=cfg.n_kv_head,
             head_dim=cfg.head_dim,
             n_rep=cfg.n_rep,
             implementation="auto",
-        ),
+        )
+    return FrozenAttn(
+        wq=get(f"h.{layer_idx}.attn.q_proj.weight"),
+        wk=get(f"h.{layer_idx}.attn.k_proj.weight"),
+        wv=get(f"h.{layer_idx}.attn.v_proj.weight"),
+        wo=get(f"h.{layer_idx}.attn.o_proj.weight"),
+        n_head=cfg.n_head,
+        n_kv_head=cfg.n_kv_head,
+        head_dim=cfg.head_dim,
+        n_rep=cfg.n_rep,
+        implementation="auto",
+    )
+
+
+def _layer_from_weights(get: WeightGetter, layer_idx: int, cfg: LlamaSimpleMLPConfig) -> GLULayer:
+    return GLULayer(
+        ln1=get(f"h.{layer_idx}.rms_1.weight"),
+        ln2=get(f"h.{layer_idx}.rms_2.weight"),
+        attn=_attn_from_weights(get, layer_idx, cfg),
         mlp=PlainMLP(
             Wfc=get(f"h.{layer_idx}.mlp.c_fc.weight"),
             Wdown=get(f"h.{layer_idx}.mlp.down_proj.weight"),
@@ -244,16 +310,19 @@ def build_decomposed_simple_mlp(
     embed: Array,
     layers: list[GLULayer],
     norm: Array,
+    lm_head: Array | TiedHead,
     cfg: LlamaSimpleMLPConfig,
     sites: tuple[SiteSpec, ...],
 ) -> GLUDecomposedModel:
-    """`build_engine_model` at the SimpleMLP anatomy — plain-GELU MLP arm, TIED output
-    head. `sites` must be canonical-ordered with dims matching `cfg`."""
+    """Build the SimpleMLP anatomy with its authored tied or untied output head.
+
+    `sites` must be canonical-ordered with dims matching `cfg`.
+    """
     return build_engine_model(
         embed=embed,
         layers=layers,
         norm=norm,
-        lm_head=TiedHead(),
+        lm_head=lm_head,
         inv_freq=plain_rope_inv_freq(cfg),
         cfg=cfg,
         sites=sites,
@@ -278,6 +347,7 @@ def target_from_weights(get: WeightGetter, cfg: LlamaSimpleMLPConfig) -> GLUDeco
         embed=get("wte.weight"),
         layers=[_layer_from_weights(get, i, cfg) for i in range(cfg.n_layer)],
         norm=get("ln_f.weight"),
+        lm_head=TiedHead() if cfg.tie_word_embeddings else get("lm_head.weight"),
         cfg=cfg,
         sites=all_site_specs(cfg),
     )
@@ -295,13 +365,13 @@ def load_target_from_pretrain_cache(
 def load_decomposed_lm_from_pretrain_cache(
     cache_dir: Path, cfg: LlamaSimpleMLPConfig, sites: tuple[SiteSpec, ...], dtype: DTypeLike
 ) -> GLUDecomposedModel:
-    """Load the `SimpleMLP` `DecomposedModel`: the full frozen model (tied embedding, all
-    blocks, final norm) as fields plus the static decomposition `sites`."""
+    """Load the full frozen model plus the static decomposition `sites`."""
     get = _checkpoint_weight_getter(cache_dir, dtype)
     return build_decomposed_simple_mlp(
         embed=get("wte.weight"),
         layers=[_layer_from_weights(get, i, cfg) for i in range(cfg.n_layer)],
         norm=get("ln_f.weight"),
+        lm_head=TiedHead() if cfg.tie_word_embeddings else get("lm_head.weight"),
         cfg=cfg,
         sites=sites,
     )

--- a/param_decomp/targets/llama_simple_mlp.py
+++ b/param_decomp/targets/llama_simple_mlp.py
@@ -254,6 +254,9 @@ class AttentionSinkFrozenAttn(FrozenAttn):
         b, h, t, _ = masked_scores.shape
         assert self.sinks.shape == (h,), (self.sinks.shape, h)
         sink_logits = jnp.broadcast_to(self.sinks[None, :, None, None], (b, h, t, 1))
+        scores_sharding = jax.typeof(masked_scores).sharding
+        if isinstance(scores_sharding, NamedSharding) and not scores_sharding.mesh.empty:
+            sink_logits = jax.sharding.reshard(sink_logits, scores_sharding)
         return jax.nn.softmax(jnp.concatenate((masked_scores, sink_logits), axis=-1), axis=-1)[
             ..., :-1
         ]

--- a/param_decomp/targets/testing.py
+++ b/param_decomp/targets/testing.py
@@ -29,6 +29,7 @@ from param_decomp.targets.glu_transformer import (
     GLUDecomposedModel,
     GLULayer,
     PlainMLP,
+    TiedHead,
     build_decomposed_lm,
     parse_site_name,
 )
@@ -171,7 +172,7 @@ def tiny_simple_mlp_decomposed_model(
     layers = _tiny_simple_mlp_layers(cfg, cfg.n_layer, layers_key)
     embed = jax.random.normal(embed_key, (cfg.vocab_size, cfg.n_embd)) * 0.02
     return build_decomposed_simple_mlp(
-        embed=embed, layers=layers, norm=jnp.ones((cfg.n_embd,)),
+        embed=embed, layers=layers, norm=jnp.ones((cfg.n_embd,)), lm_head=TiedHead(),
         cfg=cfg, sites=sites,
     )  # fmt: skip
 

--- a/param_decomp/tests/core/test_pretrain.py
+++ b/param_decomp/tests/core/test_pretrain.py
@@ -23,6 +23,7 @@ from param_decomp.pretrain.models import (
     model_logits,
 )
 from param_decomp.pretrain.train import train
+from param_decomp.target_ports.llama import causal_sink_sdpa
 from param_decomp.targets.testing import run_clean
 
 
@@ -67,11 +68,32 @@ def test_all_archs_forward():
         assert bool(jnp.isfinite(out).all())
 
 
-def test_cache_round_trip_matches_decomposition_loader():
+def test_attention_sink_is_an_extra_zero_value_softmax_slot():
+    q = jnp.zeros((1, 1, 2, 1), dtype=jnp.float32)
+    k = jnp.zeros((1, 1, 2, 1), dtype=jnp.float32)
+    v = jnp.array([[[[2.0], [4.0]]]])
+    out = causal_sink_sdpa(q, k, v, jnp.zeros((1,)), None)
+    # Query 0 splits mass between key 0 and the sink; query 1 splits it across two
+    # real keys and the sink. The sink's value is zero and therefore absent below.
+    assert jnp.allclose(out, jnp.array([[[[1.0], [2.0]]]]))
+
+
+@pytest.mark.parametrize("tie_word_embeddings,attention_sinks", [(True, False), (False, True)])
+def test_cache_round_trip_matches_decomposition_loader(
+    tie_word_embeddings: bool, attention_sinks: bool
+):
     """The written cache, read back through the decomposition trainer's loader, forwards
     bit-identically to the pretrain model — the cache-compatibility guarantee."""
-    mc = _tiny_mlp_cfg()
+    mc = _tiny_mlp_cfg().model_copy(
+        update={
+            "tie_word_embeddings": tie_word_embeddings,
+            "attention_sinks": attention_sinks,
+        }
+    )
     model = init_model(mc, jax.random.PRNGKey(1))
+    state = model.state_dict()
+    assert ("lm_head.weight" in state) is not tie_word_embeddings
+    assert ("h.0.attn.sinks" in state) is attention_sinks
     cfg = PretrainConfig(
         model=mc,
         data=NamedDataset(name="unused"),

--- a/param_decomp/tests/core/test_pretrain.py
+++ b/param_decomp/tests/core/test_pretrain.py
@@ -23,7 +23,7 @@ from param_decomp.pretrain.models import (
     model_logits,
 )
 from param_decomp.pretrain.train import train
-from param_decomp.target_ports.llama import causal_sink_sdpa
+from param_decomp.vendored_jax.llama import causal_sink_sdpa
 from param_decomp.targets.testing import run_clean
 
 

--- a/param_decomp/vendored_jax/llama.py
+++ b/param_decomp/vendored_jax/llama.py
@@ -17,6 +17,7 @@ v1 scope for the parity spike: routing == "all", no weight-delta term (both opti
 the clean + stochastic paths). RoPE uses the llama3 frequency rescaling.
 """
 
+import math
 from dataclasses import dataclass
 from typing import Literal, NamedTuple
 
@@ -166,6 +167,46 @@ def causal_sdpa(
         ),
     )
     return out.transpose(0, 2, 1, 3)
+
+
+def causal_sink_sdpa(
+    q: Array,
+    k: Array,
+    v: Array,
+    sinks: Float[Array, " h"],
+    qkv_sharding: jax.sharding.Sharding | None,
+) -> Array:
+    """Causal GQA with one learned zero-value softmax slot per query head.
+
+    This is the eager GPT-OSS sink equation: append each head's scalar to every query's
+    real-key logits, softmax over keys plus that scalar, discard the sink probability,
+    then mix values. The missing probability mass is exactly attention paid to zero.
+    """
+    assert q.ndim == k.ndim == v.ndim == 4, (q.shape, k.shape, v.shape)
+    b, h, t, hd = q.shape
+    assert sinks.shape == (h,), (sinks.shape, h)
+    assert k.shape == v.shape and k.shape[0] == b and k.shape[2:] == (t, hd), (
+        q.shape,
+        k.shape,
+        v.shape,
+    )
+    kv_heads = k.shape[1]
+    assert h % kv_heads == 0, (h, kv_heads)
+    qt, kt, vt = (a.transpose(0, 2, 1, 3) for a in (q, k, v))
+    if qkv_sharding is not None:
+        qt, kt, vt = (jax.sharding.reshard(a, qkv_sharding) for a in (qt, kt, vt))
+    q = qt.transpose(0, 2, 1, 3)
+    k = repeat_kv(kt.transpose(0, 2, 1, 3), h // kv_heads)
+    v = repeat_kv(vt.transpose(0, 2, 1, 3), h // kv_heads)
+
+    scores = jnp.einsum(
+        "bhqd,bhkd->bhqk", q.astype(jnp.float32), k.astype(jnp.float32)
+    ) / math.sqrt(hd)
+    causal = jnp.triu(jnp.ones((t, t), dtype=bool), k=1)
+    scores = jnp.where(causal, -jnp.inf, scores)
+    sink_logits = jnp.broadcast_to(sinks.astype(jnp.float32)[None, :, None, None], (b, h, t, 1))
+    probs = jax.nn.softmax(jnp.concatenate((scores, sink_logits), axis=-1), axis=-1)
+    return jnp.einsum("bhqk,bhkd->bhqd", probs[..., :-1].astype(v.dtype), v)
 
 
 # ----------------------------- component leaf (mirror ComponentLinear) -----------------------------

--- a/param_decomp/vendored_jax/llama.py
+++ b/param_decomp/vendored_jax/llama.py
@@ -205,6 +205,8 @@ def causal_sink_sdpa(
     causal = jnp.triu(jnp.ones((t, t), dtype=bool), k=1)
     scores = jnp.where(causal, -jnp.inf, scores)
     sink_logits = jnp.broadcast_to(sinks.astype(jnp.float32)[None, :, None, None], (b, h, t, 1))
+    if qkv_sharding is not None:
+        sink_logits = jax.sharding.reshard(sink_logits, jax.typeof(scores).sharding)
     probs = jax.nn.softmax(jnp.concatenate((scores, sink_logits), axis=-1), axis=-1)
     return jnp.einsum("bhqk,bhkd->bhqd", probs[..., :-1].astype(v.dtype), v)
 


### PR DESCRIPTION
## Description

Add the untied-output-head and learned attention-sink variant of the 4-layer `LlamaSimpleMLP` target to the public loader and pretrainer. Clean and decomposed forwards share the same sink-aware attention implementation, and the cache contract records both new model facts.

## Related Issue

Bridge task #1423.

## Motivation and Context

The completed #1423 decomposition and base-model bundles need a public consumer that reconstructs their exact architecture. Without this change, public `param-decomp` assumes a tied output head and plain causal attention and cannot load those artifacts faithfully.

## How Has This Been Tested?

- `pytest -q param_decomp/tests/core/test_pretrain.py param_decomp/tests/targets/test_llama_simple_mlp.py` (21 passed, 1 skipped)
- `pytest -q param_decomp/tests/core/test_config.py param_decomp/tests/targets/simple_mlp_equivalence/test_torch_equivalence.py` (22 passed, 1 skipped)
- The cache round-trip test now covers both the legacy tied/plain variant and the untied/sink variant.

## Does this PR introduce a breaking change?

No. Existing configs default to tied embeddings and no attention sinks.

## Diff breakdown

- pretrain: +98 -25
- target loader and attention primitive: +151 -20
- tests: +24 -2
- docs: +3 -2

Crew-Address: agent/i9y2
Bridge-Task: 1423
